### PR TITLE
default configuration for redis

### DIFF
--- a/db/keyval/redis/bytes_suite_test.go
+++ b/db/keyval/redis/bytes_suite_test.go
@@ -193,6 +193,12 @@ func TestConfig(t *testing.T) {
 	os.Remove(yamlFile)
 }
 
+func TestMissingConfig(t *testing.T) {
+	client, err := CreateClient(nil)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Expect(client).ShouldNot(gomega.BeNil())
+}
+
 func TestBadConfig(t *testing.T) {
 	gomega.RegisterTestingT(t)
 
@@ -206,9 +212,6 @@ func TestBadConfig(t *testing.T) {
 
 	var cfg *NodeConfig
 	client, err := CreateClient(cfg)
-	gomega.Expect(err).Should(gomega.HaveOccurred())
-	gomega.Expect(client).Should(gomega.BeNil())
-	client, err = CreateClient(nil)
 	gomega.Expect(err).Should(gomega.HaveOccurred())
 	gomega.Expect(client).Should(gomega.BeNil())
 

--- a/db/keyval/redis/config.go
+++ b/db/keyval/redis/config.go
@@ -166,7 +166,13 @@ func CreateClient(config interface{}) (Client, error) {
 	case SentinelConfig:
 		return CreateSentinelClient(cfg)
 	case nil:
-		return nil, fmt.Errorf("Configuration cannot be nil")
+		// Use default
+		def := NodeConfig{
+			Endpoint: "172.17.0.1:6379",
+			DB: 0,
+			EnableReadQueryOnSlave: false,
+		}
+		return CreateNodeClient(def)
 	}
 	return nil, fmt.Errorf("Unknown configureation type %T", config)
 }

--- a/db/keyval/redis/plugin_impl_redis.go
+++ b/db/keyval/redis/plugin_impl_redis.go
@@ -42,6 +42,9 @@ func (p *Plugin) Init() error {
 	if err != nil {
 		return err
 	}
+	if cfg == nil {
+		p.Log.Info("Redis.conf is not set, default configuration will be used")
+	}
 	client, err := CreateClient(cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
use default configuration if --redis-conf flag is not set in vpp-agent

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>