### PR TITLE
health/probes common deps.go (for all probes) + extract probe HTTP port logic (rest.ForkPluging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-# Release v1.0.5 (PLANNED)
-
-## Cassandra
-* connectivity status check
-
 # Release v1.0.4 (NOT RELEASED)
+
+## Health, status check & probes
+* status check is now registered also for Cassandra & Redis
+* new prometheus format probe support (in rpcflavor)
 
 ## Profiling
 * Logging duration (etcd connection establishment, kafka connection establishment, resync)
@@ -29,6 +28,7 @@
   Every multiplexer can create its own connection and provides access to different set of methods 
   (publishing to partition, watching on partition/offset) 
 * fixes inside Mux.NewSyncPublisher() & Mux.NewAsyncPublisher() related to previous partition changes
+* TODO offset improvements
 * Known Issues:
   * More than one network connection to Kafka (multiple instances of MUX)
   * TODO Minimalistic examples & documentation for Kafka API will be improved in a later release.

--- a/config/plugin_config.go
+++ b/config/plugin_config.go
@@ -16,6 +16,9 @@ import (
 // FlagSuffix is added to plugin name while loading plugins configuration
 const FlagSuffix = "-config"
 
+// EnvSuffix is added to plugin name while loading plugins configuration from ENV variable
+const EnvSuffix = "_CONFIG"
+
 // DirFlag used as flag name (see implementation in declareFlags())
 // It is used to define default directory where config files reside.
 // This flag name is calculated from the name of the plugin.
@@ -25,7 +28,7 @@ const DirFlag = "config-dir"
 const DirDefault = "."
 
 // DirUsage used as flag usage (see implementation in declareFlags())
-const DirUsage = "Location of the configuration files; also set via 'CONFIG_DIR' env variable."
+const DirUsage = "Location of the configuration files; also set via '" + EnvSuffix + "_DIR' env variable."
 
 // PluginConfig is API for plugins to access configuration.
 //
@@ -45,7 +48,26 @@ type PluginConfig interface {
 // to read it's configuration.
 //
 // It tries to lookup `plugin + "-config"` in flags.
-func ForPlugin(pluginName string) PluginConfig {
+//
+// opts (used for defining flag if it was not allready defined):
+// - usage
+// - default value
+func ForPlugin(pluginName string, opts ...string) PluginConfig {
+	flgName := pluginName + FlagSuffix
+	flg := flag.CommandLine.Lookup(flgName)
+	if flg == nil {
+		var  flagDefault, flagUsage string
+		if len(opts) > 0 {
+			flagDefault = opts[0]
+		} else {
+			flagDefault = pluginName + ".conf"
+		}
+		if len(opts) > 1 {
+			flagUsage = opts[1]
+		}
+		flag.String(flgName, flagDefault, flagUsage)
+	}
+
 	return &pluginConfig{pluginName: pluginName}
 }
 

--- a/config/plugin_config.go
+++ b/config/plugin_config.go
@@ -47,8 +47,8 @@ type PluginConfig interface {
 // ForPlugin returns API that is injectable to a particular Plugin
 // to read it's configuration.
 //
-// It tries to lookup `plugin + "-config"` in flags.
-//
+// It tries to lookup `plugin + "-config"` in flags and declare
+// the flag if it still not exists. It uses following opts.
 // opts (used for defining flag if it was not allready defined):
 // - usage
 // - default value

--- a/core/list_flavor_plugin.go
+++ b/core/list_flavor_plugin.go
@@ -32,7 +32,7 @@ type Flavor interface {
 // ListPluginsInFlavor lists plugins in a Flavor.
 // It extracts all plugins and returns them as a slice of NamedPlugins.
 func ListPluginsInFlavor(flavor Flavor) (plugins []*NamedPlugin) {
-	uniqueness := map[PluginName]Plugin{}
+	uniqueness := map[Plugin] /*nil*/ interface{}{}
 	l, err := listPluginsInFlavor(reflect.ValueOf(flavor), uniqueness)
 	if err != nil {
 		logroot.StandardLogger().Error("Invalid argument - it does not satisfy the Flavor interface")
@@ -52,7 +52,9 @@ func ListPluginsInFlavor(flavor Flavor) (plugins []*NamedPlugin) {
 // must satisfy either the Plugin or the Flavor interface. If they do not,
 // an error is logged, but the function does not return an error.
 // in the argument
-func listPluginsInFlavor(flavorValue reflect.Value, uniqueness map[PluginName]Plugin) ([]*NamedPlugin, error) {
+func listPluginsInFlavor(flavorValue reflect.Value, uniqueness map[Plugin] /*nil*/ interface{}) ([]*NamedPlugin, error) {
+	logroot.StandardLogger().Error("inspect flavor structure ", flavorValue.Type())
+
 	var res []*NamedPlugin
 
 	flavorType := flavorValue.Type()
@@ -86,12 +88,26 @@ func listPluginsInFlavor(flavorValue reflect.Value, uniqueness map[PluginName]Pl
 			}
 
 			fieldVal := flavorValue.Field(i)
-			plug := fieldPlugin(field, fieldVal, pluginType)
-			if plug != nil {
-				_, found := uniqueness[PluginName(field.Name)]
-				if !found {
-					uniqueness[PluginName(field.Name)] = plug
-					res = append(res, &NamedPlugin{PluginName: PluginName(field.Name), Plugin: plug})
+			plug, implementsPlugin := fieldPlugin(field, fieldVal, pluginType)
+			if implementsPlugin {
+				if plug != nil {
+					_, found := uniqueness[plug]
+					if !found {
+						uniqueness[plug] = nil
+						res = append(res, &NamedPlugin{PluginName: PluginName(field.Name), Plugin: plug})
+
+						logroot.StandardLogger().
+							WithField("fieldName", field.Name).
+							Debug("Found plugin in flavor ", field.Type)
+					} else {
+						logroot.StandardLogger().
+							WithField("fieldName", field.Name).
+							Debug("Found plugin in flavor with non unique name")
+					}
+				} else {
+					logroot.StandardLogger().
+						WithField("fieldName", field.Name).
+						Debug("Found nil plugin in flavor")
 				}
 			} else {
 				// try to inspect flavor structure recursively
@@ -112,22 +128,29 @@ func listPluginsInFlavor(flavorValue reflect.Value, uniqueness map[PluginName]Pl
 
 // fieldPlugin determines if a given field satisfies the Plugin interface.
 // If yes, the plugin value is returned; if not, nil is returned.
-func fieldPlugin(field reflect.StructField, fieldVal reflect.Value, pluginType reflect.Type) Plugin {
+func fieldPlugin(field reflect.StructField, fieldVal reflect.Value, pluginType reflect.Type) (
+	plugin Plugin, implementsPlugin bool) {
+
 	switch fieldVal.Kind() {
 	case reflect.Struct:
 		ptrType := reflect.PtrTo(fieldVal.Type())
-		if ptrType.Implements(pluginType) && fieldVal.CanAddr() {
-			if plug, ok := fieldVal.Addr().Interface().(Plugin); ok {
-				return plug
+		if ptrType.Implements(pluginType) {
+			if fieldVal.CanAddr() {
+				if plug, ok := fieldVal.Addr().Interface().(Plugin); ok {
+					return plug, true
+				}
 			}
+			return nil, true
 		}
 	case reflect.Ptr, reflect.Interface:
-		if fieldVal.IsNil() {
-			logroot.StandardLogger().WithField("fieldName", field.Name).Debug("Field is nil ", pluginType)
-		} else if plug, ok := fieldVal.Interface().(Plugin); ok {
-			return plug
+		if plug, ok := fieldVal.Interface().(Plugin); ok {
+			if fieldVal.IsNil() {
+				logroot.StandardLogger().WithField("fieldName", field.Name).Debug("Field is nil ", pluginType)
+				return nil, true
+			}
+			return plug, true
 		}
 
 	}
-	return nil
+	return nil, false
 }

--- a/examples/logs_lib/custom/custom.go
+++ b/examples/logs_lib/custom/custom.go
@@ -35,7 +35,7 @@ func main() {
 
 	// setup fields that will be added to all subsequent log entries
 	logger.SetStaticFields(map[string]interface{}{"component": "componentXY", "key": "value"})
-
+logrus.DefaultLogger()
 	logger.WithFields(logging.Fields{
 		"CM_IP": "10.1.10",
 	}).Debug("Cable modem is online")

--- a/health/probe/deps_probe.go
+++ b/health/probe/deps_probe.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ligato/cn-infra/rpc/rest"
 )
 
-// PluginDeps lists dependencies of all proble plugins.
+// Deps lists dependencies of all proble plugins.
 type Deps struct {
 	local.PluginLogDeps                       // inject
 	HTTP        rest.HTTPHandlers             // inject

--- a/health/probe/deps_probe.go
+++ b/health/probe/deps_probe.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe implements Liveness/Readiness/Prometheus health/metrics HTTP handlers.
+package probe
+
+import (
+	"github.com/ligato/cn-infra/flavors/local"
+	"github.com/ligato/cn-infra/health/statuscheck"
+	"github.com/ligato/cn-infra/rpc/rest"
+)
+
+// PluginDeps lists dependencies of all proble plugins.
+type Deps struct {
+	local.PluginLogDeps                       // inject
+	HTTP        rest.HTTPHandlers             // inject
+	StatusCheck statuscheck.AgentStatusReader // inject
+}

--- a/health/probe/doc.go
+++ b/health/probe/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe implements HTTP probes: the K8s readiness and liveliness probe handlers + Prometheus format.
+package probe

--- a/health/probe/plugin_impl_probes.go
+++ b/health/probe/plugin_impl_probes.go
@@ -12,80 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package probe implements the K8s readiness and liveliness probe handlers.
 package probe
 
 import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/ligato/cn-infra/core"
-	"github.com/ligato/cn-infra/flavors/local"
-	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/cn-infra/health/statuscheck/model/status"
-	"github.com/ligato/cn-infra/logging"
-	"github.com/ligato/cn-infra/rpc/rest"
-	"github.com/ligato/cn-infra/utils/safeclose"
-	"github.com/namsral/flag"
 	"github.com/unrolled/render"
 )
 
 const (
-	// Default port used for http and probing.
-	defaultPort               = "9191"
 	livenessProbePath  string = "/liveness"  // liveness probe URL
 	readinessProbePath string = "/readiness" // readiness probe URL
 )
 
-var (
-	httpPort string
-)
-
-// init is here only for parsing program arguments
-func init() {
-	flag.StringVar(&httpPort, "http-probe-port", defaultPort,
-		"Listen port for the Agent's HTTPProbe server.")
-}
-
 // Plugin struct holds all plugin-related data.
 type Plugin struct {
 	Deps
-
-	customProbe bool
 }
 
-// Deps lists dependencies of the probe plugin.
-type Deps struct {
-	local.PluginLogDeps                               // inject
-	HTTP                *rest.Plugin                  // inject (optional)
-	StatusCheck         statuscheck.AgentStatusReader // inject
-}
-
-// Init may create a new (custom) instance of HTTP if the injected instance uses
-// different HTTP port than requested.
+// Init does nothing
 func (p *Plugin) Init() (err error) {
-	// Start Init() and AfterInit() for new probe in case the port is different
-	// from agent http.
-	if p.HTTP.HTTPport != httpPort {
-		childPlugNameHTTP := p.String() + "-HTTP"
-		p.HTTP = &rest.Plugin{
-			Deps: rest.Deps{
-				Log:        logging.ForPlugin(childPlugNameHTTP, p.Log),
-				PluginName: core.PluginName(childPlugNameHTTP),
-				HTTPport: httpPort,
-			},
-		}
-		err := p.HTTP.Init()
-		if err != nil {
-			return err
-		}
-		err = p.HTTP.AfterInit()
-		if err != nil {
-			return err
-		}
-
-		p.customProbe = true
-	}
 	return nil
 }
 
@@ -93,7 +41,7 @@ func (p *Plugin) Init() (err error) {
 func (p *Plugin) AfterInit() error {
 	if p.HTTP != nil {
 		if p.StatusCheck != nil {
-			p.Log.Infof("Starting health http-probe on port %v", p.HTTP.HTTPport)
+			p.Log.Infof("Starting health http-probe on port %v", p.HTTP.GetPort())
 			p.HTTP.RegisterHTTPHandler(livenessProbePath, p.livenessProbeHandler, "GET")
 			p.HTTP.RegisterHTTPHandler(readinessProbePath, p.readinessProbeHandler, "GET")
 
@@ -102,16 +50,6 @@ func (p *Plugin) AfterInit() error {
 		}
 	} else {
 		p.Log.Info("Unable to register http-probe handler, HTTP is nil")
-	}
-
-	return nil
-}
-
-// Close shutdowns HTTP if a custom instance was created in Init().
-func (p *Plugin) Close() error {
-	if p.customProbe {
-		_, err := safeclose.CloseAll(p.HTTP)
-		return err
 	}
 
 	return nil

--- a/health/probe/plugin_impl_prometheus.go
+++ b/health/probe/plugin_impl_prometheus.go
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package probe implements Prometheus health/metrics handlers.
 package probe
 
 import (
 	"net/http"
 
-	"github.com/ligato/cn-infra/flavors/local"
-	"github.com/ligato/cn-infra/health/statuscheck"
-	"github.com/ligato/cn-infra/rpc/rest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/unrolled/render"
@@ -72,16 +68,7 @@ const (
 
 // PrometheusPlugin struct holds all plugin-related data.
 type PrometheusPlugin struct {
-	// FIXME: I know it's unconventional.  But to avoid name collision till probe.Deps is extracted and shared.
-	PluginDeps
-}
-
-// PluginDeps lists dependencies of the Prometheus plugin.
-// FIXME: I know it's unconventional.  But to avoid name collision till probe.Deps is extracted and shared.
-type PluginDeps struct {
-	local.PluginLogDeps                               // inject
-	HTTP                rest.HTTPHandlers             // inject
-	StatusCheck         statuscheck.AgentStatusReader // inject
+	Deps
 }
 
 // Init may create a new (custom) instance of HTTP if the injected instance uses

--- a/rpc/rest/plugin_api_rest.go
+++ b/rpc/rest/plugin_api_rest.go
@@ -34,4 +34,7 @@ type HTTPHandlers interface {
 	RegisterHTTPHandler(path string,
 		handler func(formatter *render.Render) http.HandlerFunc,
 		methods ...string) *mux.Route
+
+	// GetPort returns configured port number (for debugging purposes)
+	GetPort() int
 }

--- a/rpc/rest/plugin_impl_fork.go
+++ b/rpc/rest/plugin_impl_fork.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ligato/cn-infra/config"
+	"github.com/ligato/cn-infra/core"
+	"github.com/ligato/cn-infra/datasync/grpcsync"
+	"github.com/ligato/cn-infra/logging"
+	"github.com/unrolled/render"
+)
+
+// ForkPlugin checks the configuration and based on this it
+// delegates API calls to new instance or existing instance of HTTP server
+type ForkPlugin struct {
+	Deps ForkDeps
+	*Config
+
+	delegate  HTTPHandlers
+	newPlugin *Plugin //set only if delegate != Deps.DefaultHTTP
+
+	// Used mainly for testing purposes
+	listenAndServe ListenAndServe
+
+	server     io.Closer
+	mx         *mux.Router
+	formatter  *render.Render
+	grpcServer *grpcsync.Adapter
+}
+
+// Deps lists the dependencies of the Rest plugin.
+type ForkDeps struct {
+	// DefaultHTTP is used if there is no different configuration
+	DefaultHTTP HTTPHandlers //inject
+
+	Log        logging.PluginLogger //inject
+	PluginName core.PluginName      //inject
+	config.PluginConfig             //inject
+}
+
+// Init checks config if the port is different that it creates ne HTTP server
+func (plugin *ForkPlugin) Init() (err error) {
+	if plugin.Config == nil {
+		plugin.Config = DefaultConfig()
+	}
+	if err := PluginConfig(plugin.Deps.PluginConfig, plugin.Config, plugin.Deps.PluginName); err != nil {
+		return err
+	}
+
+	probePort := plugin.Config.GetPort()
+	plugin.Deps.Log.WithField("probePort", probePort).Info("init")
+	if probePort > 0 && probePort != plugin.Deps.DefaultHTTP.GetPort() {
+		childPlugNameHTTP := plugin.String() + "-HTTP"
+		plugin.newPlugin = &Plugin{Deps: Deps{
+			Log:        logging.ForPlugin(childPlugNameHTTP, plugin.Deps.Log),
+			PluginName: core.PluginName(childPlugNameHTTP),
+		}, Config: plugin.Config,
+		}
+
+		plugin.delegate = plugin.newPlugin
+	} else {
+		plugin.delegate = plugin.Deps.DefaultHTTP
+	}
+
+
+	if plugin.newPlugin != nil {
+		return plugin.newPlugin.Init()
+	}
+
+	return err
+}
+
+// RegisterHTTPHandler registers HTTP <handler> at the given <path>.
+// (delegated call)
+func (plugin *ForkPlugin) RegisterHTTPHandler(path string,
+	handler func(formatter *render.Render) http.HandlerFunc,
+	methods ...string) *mux.Route {
+
+	if plugin.delegate != nil {
+		return plugin.delegate.RegisterHTTPHandler(path, handler, methods...)
+	}
+
+	plugin.Deps.Log.Warn("not set delegate")
+	return nil
+}
+
+// GetPort returns plugin configuration port
+// (delegated call)
+func (plugin *ForkPlugin) GetPort() int {
+	if plugin.delegate != nil {
+		return plugin.delegate.GetPort()
+	}
+	return 0
+}
+
+// AfterInit starts the HTTP server.
+// (only if port was different in Init())
+func (plugin *ForkPlugin) AfterInit() error {
+	if plugin.newPlugin != nil {
+		return plugin.newPlugin.AfterInit()
+	}
+	return nil
+}
+
+// Close stops the HTTP server.
+// (only if port was different in Init())
+func (plugin *ForkPlugin) Close() error {
+	if plugin.newPlugin != nil {
+		return plugin.newPlugin.Close()
+	}
+	return nil
+}
+
+// String returns plugin name (if not set defaults to "HTTP-FORK")
+func (plugin *ForkPlugin) String() string {
+	if plugin.Deps.PluginName != "" {
+		return string(plugin.Deps.PluginName)
+	}
+	return "HTTP-FORK"
+}

--- a/rpc/rest/plugin_impl_fork.go
+++ b/rpc/rest/plugin_impl_fork.go
@@ -44,7 +44,7 @@ type ForkPlugin struct {
 	grpcServer *grpcsync.Adapter
 }
 
-// Deps lists the dependencies of the Rest plugin.
+// ForkDeps lists the dependencies of the Fork on top of Rest plugin.
 type ForkDeps struct {
 	// DefaultHTTP is used if there is no different configuration
 	DefaultHTTP HTTPHandlers //inject

--- a/rpc/rest/plugin_impl_rest.go
+++ b/rpc/rest/plugin_impl_rest.go
@@ -21,32 +21,25 @@ import (
 	"fmt"
 
 	"github.com/gorilla/mux"
+	"github.com/ligato/cn-infra/config"
 	"github.com/ligato/cn-infra/core"
 	"github.com/ligato/cn-infra/datasync/grpcsync"
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/utils/safeclose"
-	"github.com/namsral/flag"
 	"github.com/unrolled/render"
 )
 
 const (
 	// DefaultHTTPPort is used during HTTP server startup unless different port was configured
 	DefaultHTTPPort = "9191"
+	DefaultIP       = "0.0.0.0"
+	DefaultEndpoint = DefaultIP + ":" + DefaultHTTPPort
 )
-
-var (
-	httpPort string
-)
-
-// init is here only for parsing program arguments
-func init() {
-	flag.StringVar(&httpPort, "http-port", DefaultHTTPPort,
-		"Listen port for the Agent's HTTP server.")
-}
 
 // Plugin struct holds all plugin-related data.
 type Plugin struct {
 	Deps
+	*Config
 
 	// Used mainly for testing purposes
 	listenAndServe ListenAndServe
@@ -61,30 +54,23 @@ type Plugin struct {
 type Deps struct {
 	Log        logging.PluginLogger //inject
 	PluginName core.PluginName      //inject
-
-	// Used to simplify if not whole config needs to be configured
-	HTTPport string // inject (optional)
-	// Config is a rich alternative comparing to HTTPport
-	// TODO Config *Config
+	config.PluginConfig
 }
 
 // Init is the plugin entry point called by Agent Core
 // - It prepares Gorilla MUX HTTP Router
-// - Registers grpc transport
 func (plugin *Plugin) Init() (err error) {
-	if plugin.HTTPport == "" /*TODO && plugin.Config == nil*/ {
-		plugin.HTTPport = httpPort
+	if plugin.Config == nil {
+		plugin.Config = DefaultConfig()
+	}
+	if err := PluginConfig(plugin.Deps.PluginConfig, plugin.Config, plugin.Deps.PluginName); err != nil {
+		return err
 	}
 
 	plugin.mx = mux.NewRouter()
 	plugin.formatter = render.New(render.Options{
 		IndentJSON: true,
 	})
-
-	//TODO separate plugin:
-	//plugin.grpcServer = grpcsync.NewAdapter()
-	//plugin.Debug("grpctransp: ", plugin.grpcServer)
-	//err = datasync.RegisterTransport(&syncbase.Adapter{Watcher: plugin.grpcServer})
 
 	return err
 }
@@ -93,18 +79,28 @@ func (plugin *Plugin) Init() (err error) {
 func (plugin *Plugin) RegisterHTTPHandler(path string,
 	handler func(formatter *render.Render) http.HandlerFunc,
 	methods ...string) *mux.Route {
+	plugin.Log.Debug("Register handler ", path)
+
 	return plugin.mx.HandleFunc(path, handler(plugin.formatter)).Methods(methods...)
+}
+
+// GetPort returns plugin configuration port
+func (plugin *Plugin) GetPort() int {
+	if plugin.Config != nil {
+		return plugin.Config.GetPort()
+	}
+	return 0
 }
 
 // AfterInit starts the HTTP server.
 func (plugin *Plugin) AfterInit() (err error) {
 	var cfgCopy Config
-	/*TODO if plugin.Config != nil {
+	if plugin.Config != nil {
 		cfgCopy = *plugin.Config
-	}*/
+	}
 
 	if cfgCopy.Endpoint == "" {
-		cfgCopy.Endpoint = fmt.Sprintf("0.0.0.0:%s", plugin.HTTPport)
+		cfgCopy.Endpoint = fmt.Sprintf("0.0.0.0:%s", DefaultHTTPPort)
 	}
 
 	if plugin.listenAndServe != nil {
@@ -121,4 +117,12 @@ func (plugin *Plugin) AfterInit() (err error) {
 func (plugin *Plugin) Close() error {
 	_, err := safeclose.CloseAll(plugin.grpcServer, plugin.server)
 	return err
+}
+
+// String returns plugin name (if not set defaults to "HTTP")
+func (plugin *Plugin) String() string {
+	if plugin.Deps.PluginName != "" {
+		return string(plugin.Deps.PluginName)
+	}
+	return "HTTP"
 }

--- a/rpc/rest/plugin_impl_rest.go
+++ b/rpc/rest/plugin_impl_rest.go
@@ -32,7 +32,9 @@ import (
 const (
 	// DefaultHTTPPort is used during HTTP server startup unless different port was configured
 	DefaultHTTPPort = "9191"
-	DefaultIP       = "0.0.0.0"
+	// DefaultIP 0.0.0.0
+	DefaultIP = "0.0.0.0"
+	// DefaultEndpoint 0.0.0.0:9191
 	DefaultEndpoint = DefaultIP + ":" + DefaultHTTPPort
 )
 

--- a/rpc/rest/plugin_impl_rest.go
+++ b/rpc/rest/plugin_impl_rest.go
@@ -94,14 +94,7 @@ func (plugin *Plugin) GetPort() int {
 
 // AfterInit starts the HTTP server.
 func (plugin *Plugin) AfterInit() (err error) {
-	var cfgCopy Config
-	if plugin.Config != nil {
-		cfgCopy = *plugin.Config
-	}
-
-	if cfgCopy.Endpoint == "" {
-		cfgCopy.Endpoint = fmt.Sprintf("0.0.0.0:%s", DefaultHTTPPort)
-	}
+	cfgCopy := *plugin.Config
 
 	if plugin.listenAndServe != nil {
 		plugin.server, err = plugin.listenAndServe(cfgCopy, plugin.mx)

--- a/rpc/rest/plugin_impl_rest.go
+++ b/rpc/rest/plugin_impl_rest.go
@@ -18,8 +18,6 @@ import (
 	"io"
 	"net/http"
 
-	"fmt"
-
 	"github.com/gorilla/mux"
 	"github.com/ligato/cn-infra/config"
 	"github.com/ligato/cn-infra/core"


### PR DESCRIPTION
Junmin, I did refactoring that extracted HTTP{} code from health/probe package (using rest.ForkPlugin in rpc flavor). Please take a look at the health/probe changes.

Milan, please have a look on overall cn-infra changes related to configs & rpc flavor.
