### PR TITLE
Add logger level map and default level to registry

### DIFF
--- a/examples/logs-plugin/logs.conf
+++ b/examples/logs-plugin/logs.conf
@@ -1,6 +1,7 @@
+defaultLevel: debug
 loggers:
  - name: "defaultLogger"
-   level: debug
+   level: info
  - name: "logs-example"
    level: debug
  - name: "logs-examplechildLogger"

--- a/examples/logs-plugin/main.go
+++ b/examples/logs-plugin/main.go
@@ -70,6 +70,10 @@ func (plugin *ExamplePlugin) Init() (err error) {
 	childLogger := plugin.Log.NewLogger("childLogger")
 	// Usage of custom loggers
 	childLogger.Infof("Log using named logger with name: %v", childLogger.GetName())
+	childLogger.Debug("Debug log using childLogger!")
+
+	childLogger2 := plugin.Log.NewLogger("childLogger2")
+	childLogger2.Debug("Debug log using childLogger2!")
 
 	// End the example
 	plugin.Log.Info("logs in plugin example finished, sending shutdown ...")

--- a/logging/logrus/registry_test.go
+++ b/logging/logrus/registry_test.go
@@ -71,7 +71,7 @@ func TestGetSetLevel(t *testing.T) {
 
 	//non-existing logger
 	err = logRegistry.SetLevel("unknown", level)
-	gomega.Expect(err).NotTo(gomega.BeNil())
+	gomega.Expect(err).To(gomega.BeNil()) // will be kept in logger level map in registry
 
 	_, err = logRegistry.GetLevel("unknown")
 	gomega.Expect(err).NotTo(gomega.BeNil())


### PR DESCRIPTION
- registry now keeps map for logger levels and sets the level in NewLogger
- config now supports `defaultLevel` which sets the level to all loggers with undefined level
- it is possible to use env variable `INITIAL_LOGLVL` to set the initial log level for all loggers