### PR TITLE
remove unwanted transport adapter check

### DIFF
--- a/datasync/aggregator.go
+++ b/datasync/aggregator.go
@@ -66,9 +66,6 @@ func (ta *CompositeKVProtoWatcher) Watch(resyncName string, changeChan chan Chan
 // Put writes data to all aggregated transports.
 // This function implements KeyProtoValWriter.Put().
 func (ta *CompositeKVProtoWriter) Put(key string, data proto.Message, opts ...PutOption) error {
-	if len(ta.Adapters) == 0 {
-		return fmt.Errorf("no transport is available in aggregator")
-	}
 	var wasError error
 	for _, transport := range ta.Adapters {
 		err := transport.Put(key, data, opts...)

--- a/datasync/aggregator.go
+++ b/datasync/aggregator.go
@@ -15,8 +15,6 @@
 package datasync
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/ligato/cn-infra/utils/safeclose"
 )


### PR DESCRIPTION
Signed-off-by: Vladimir Lavor <vlavor@cisco.com>

Transport aggregator returns an error in case there is no transport available.  With the possibility of omitting to send status data, this error is no longer reasonable.  

@ondrej-fabry please add this change to the vpp-agent