### PR TITLE
Export global transport instance of Registry and cleanup code

### DIFF
--- a/datasync/kvdbsync/local/global_api.go
+++ b/datasync/kvdbsync/local/global_api.go
@@ -15,24 +15,14 @@
 package local
 
 import (
-	"sync"
-
 	"github.com/ligato/cn-infra/datasync/syncbase"
 )
 
-var (
-	gTransport       *syncbase.Registry
-	gTransportAccess sync.Mutex
-)
+// DefaultTransport is a default registry.
+var DefaultTransport = syncbase.NewRegistry()
 
-// Get returns global singleton instance.
+// Get returns the global singleton instance.
 func Get() *syncbase.Registry {
-	gTransportAccess.Lock()
-	defer gTransportAccess.Unlock()
-
-	if gTransport == nil {
-		gTransport = syncbase.NewRegistry()
-	}
-
-	return gTransport
+	// TODO: obsolete, use DefaultTransport directly instead
+	return DefaultTransport
 }

--- a/datasync/kvdbsync/watch_impl.go
+++ b/datasync/kvdbsync/watch_impl.go
@@ -24,6 +24,10 @@ import (
 	"github.com/ligato/cn-infra/logging/logrus"
 )
 
+const (
+	resyncTimeout = time.Second * 15
+)
+
 // WatchBrokerKeys implements go routines on top of Change & Resync channels.
 type watchBrokerKeys struct {
 	resyncReg  resync.Registration
@@ -138,7 +142,7 @@ func (keys *watchBrokerKeys) resync() error {
 		if err != nil {
 			return err
 		}
-	case <-time.After(4 * time.Second):
+	case <-time.After(resyncTimeout):
 		logrus.DefaultLogger().Warn("Timeout of resync callback")
 	}
 	return nil

--- a/datasync/syncbase/done.go
+++ b/datasync/syncbase/done.go
@@ -59,6 +59,7 @@ func (ev *DoneCallback) Done(err error) {
 // AggregateDone can be reused to avoid repetitive code that triggers a slice of events and waits until it is finished.
 func AggregateDone(events []func(chan error), done chan error) {
 	partialDone := make(chan error, 5)
+
 	go collectDoneEvents(partialDone, done, len(events))
 
 	for _, event := range events {
@@ -83,5 +84,6 @@ func collectDoneEvents(partialDone, done chan error, evCount int) {
 			}
 		}
 	}
+
 	done <- lastError
 }


### PR DESCRIPTION
Changes in this PR:
- allows setting global transport instance of local Registry to new instance (useful in tests)
- all timeouts are now constants
- increased default timeouts for resync
- cleaned up some code
  