### PR TITLE
remove field 'owner' from the in-memory mapping

### DIFF
--- a/idxmap/api.go
+++ b/idxmap/api.go
@@ -71,8 +71,6 @@ type NamedMappingRW interface {
 // part that does not contain metadata of type interface{} thus it can be reused
 // in mapping with typed metadata.
 type NamedMappingEvent struct {
-	// The owner plugin of the registry (use also as namespace)
-	Owner core.PluginName
 	// Logical name of the object
 	Name string
 	// Del denotes a type of change

--- a/idxmap/mem/doc.go
+++ b/idxmap/mem/doc.go
@@ -18,9 +18,9 @@
 // To create new mapping run:
 //	   import "github.com/ligato/cn-infra/idxmap/mem"
 //
-//     mapping := mem.NewNamedMapping(logger, "owner", "title", indexFunc)
+//     mapping := mem.NewNamedMapping(logger, "title", indexFunc)
 //
-// Owner and title are used for identification of the mapping.
+// Title is used for identification of the mapping.
 // IndexFunc extracts secondary indexes from the stored item.
 //
 // To insert a new item into the mapping, execute:

--- a/idxmap/mem/inmemory_name_mapping.go
+++ b/idxmap/mem/inmemory_name_mapping.go
@@ -45,7 +45,6 @@ type memNamedMapping struct {
 	indexes map[string] /* index name */ map[string] /* index value */ *nameSet
 	// subscribers to whom notifications are delivered
 	subscribers sync.Map //map[core.PluginName]func(idxmap.NamedMappingGenericEvent)
-	owner       core.PluginName
 	title       string
 }
 
@@ -53,14 +52,13 @@ type memNamedMapping struct {
 // of idxmap.NamedMappingRW
 // An index function that builds secondary indexes for an item can be defined
 // and passed as <indexFunction>.
-func NewNamedMapping(logger logging.Logger, owner core.PluginName, title string,
+func NewNamedMapping(logger logging.Logger, title string,
 	indexFunction func(interface{}) map[string][]string) idxmap.NamedMappingRW {
 	mem := memNamedMapping{}
 	mem.Logger = logger
 	mem.nameToIdx = map[string]*mappingItem{}
 	mem.indexes = map[string]map[string]*nameSet{}
 	mem.createIndexes = indexFunction
-	mem.owner = owner
 	mem.title = title
 	return &mem
 }
@@ -236,7 +234,6 @@ func (mem *memNamedMapping) publishToChannel(name string, value interface{}) {
 
 		if clb != nil {
 			dto := idxmap.NamedMappingGenericEvent{NamedMappingEvent: idxmap.NamedMappingEvent{
-				Owner:         mem.owner,
 				RegistryTitle: mem.title,
 				Name:          name,
 				Del:           false},
@@ -257,7 +254,6 @@ func (mem *memNamedMapping) publishDelToChannel(name string, value interface{}) 
 
 		if clb != nil {
 			dto := idxmap.NamedMappingGenericEvent{NamedMappingEvent: idxmap.NamedMappingEvent{
-				Owner:         mem.owner,
 				RegistryTitle: mem.title,
 				Name:          name,
 				Del:           true},

--- a/idxmap/mem/inmemory_name_mapping_test.go
+++ b/idxmap/mem/inmemory_name_mapping_test.go
@@ -26,7 +26,7 @@ import (
 func TestNewNamedMappingMem(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	title := "Title"
-	mapping := NewNamedMapping(logrus.DefaultLogger(), "owner", title, nil)
+	mapping := NewNamedMapping(logrus.DefaultLogger(), title, nil)
 	returnedTitle := mapping.GetRegistryTitle()
 	gomega.Expect(returnedTitle).To(gomega.BeEquivalentTo(title))
 
@@ -36,7 +36,7 @@ func TestNewNamedMappingMem(t *testing.T) {
 
 func TestUpdateMetadata(t *testing.T) {
 	gomega.RegisterTestingT(t)
-	mapping := NewNamedMapping(logrus.DefaultLogger(), "owner", "title", nil)
+	mapping := NewNamedMapping(logrus.DefaultLogger(), "title", nil)
 
 	success := mapping.Update("Name1", "value1")
 	gomega.Expect(success).To(gomega.BeFalse())
@@ -56,7 +56,7 @@ func TestUpdateMetadata(t *testing.T) {
 
 func TestCrudOps(t *testing.T) {
 	gomega.RegisterTestingT(t)
-	mapping := NewNamedMapping(logrus.DefaultLogger(), "owner", "title", nil)
+	mapping := NewNamedMapping(logrus.DefaultLogger(), "title", nil)
 
 	mapping.Put("Name1", "value1")
 	meta, found := mapping.GetValue("Name1")
@@ -94,7 +94,7 @@ func TestCrudOps(t *testing.T) {
 func TestSecondaryIndexes(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	const secondaryIx = "secondary"
-	mapping := NewNamedMapping(logrus.DefaultLogger(), "owner", "title", func(meta interface{}) map[string][]string {
+	mapping := NewNamedMapping(logrus.DefaultLogger(), "title", func(meta interface{}) map[string][]string {
 		res := map[string][]string{}
 		if str, ok := meta.(string); ok {
 			res[secondaryIx] = []string{str}
@@ -135,7 +135,7 @@ func TestSecondaryIndexes(t *testing.T) {
 
 func TestNotifications(t *testing.T) {
 	gomega.RegisterTestingT(t)
-	mapping := NewNamedMapping(logrus.DefaultLogger(), "owner", "title", nil)
+	mapping := NewNamedMapping(logrus.DefaultLogger(), "title", nil)
 
 	ch := make(chan idxmap.NamedMappingGenericEvent, 10)
 	err := mapping.Watch("subscriber", idxmap.ToChan(ch))


### PR DESCRIPTION
Field 'owner' served for mapping identification (according to comments) but was not used anywhere in the code.

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>