### PR TITLE
Handle SIGTERM in EventLoopWithInterrupt

### DIFF
--- a/core/event_loop.go
+++ b/core/event_loop.go
@@ -17,11 +17,12 @@ package core
 import (
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 // EventLoopWithInterrupt starts an instance of the agent created with NewAgent().
-// Agent is stopped when <closeChan> is closed or a user interrupt (SIGINT)
-// is received.
+// Agent is stopped when <closeChan> is closed, a user interrupt (SIGINT), or a
+// terminate signal (SIGTERM) is received.
 func EventLoopWithInterrupt(agent *Agent, closeChan chan struct{}) error {
 	err := agent.Start()
 	if err != nil {
@@ -31,6 +32,7 @@ func EventLoopWithInterrupt(agent *Agent, closeChan chan struct{}) error {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
+	signal.Notify(sigChan, syscall.SIGTERM)
 	select {
 	case <-sigChan:
 		agent.Println("Interrupt received, returning.")


### PR DESCRIPTION
This handles SIGTERM in addition to SIGINT. Relevant for the cases where the
running program is sent SIGTERM, such as when running as a daemonset.

Signed-off-by: Kyle Mestery <mestery@mestery.com>