### PR TITLE
in-memory mapping method 'update' can trigger events

### DIFF
--- a/idxmap/api.go
+++ b/idxmap/api.go
@@ -79,6 +79,10 @@ type NamedMappingEvent struct {
 	// - it is true if an item was removed
 	// - it false if an item was added or updated
 	Del bool
+	// Update denotes a type of change
+	// - it is true if and item metadata was updated
+	// - it is false if an item was added or removed
+	Update bool
 	// RegistryTitle identifies the registry (NameToIndexMapping)
 	RegistryTitle string
 }

--- a/idxmap/mem/inmemory_name_mapping_test.go
+++ b/idxmap/mem/inmemory_name_mapping_test.go
@@ -150,6 +150,7 @@ func TestNotifications(t *testing.T) {
 	case notif := <-ch:
 		gomega.Expect(notif.RegistryTitle).To(gomega.BeEquivalentTo("title"))
 		gomega.Expect(notif.Del).To(gomega.BeFalse())
+		gomega.Expect(notif.Update).To(gomega.BeFalse())
 		gomega.Expect(notif.Name).To(gomega.BeEquivalentTo("Name1"))
 		gomega.Expect(notif.Value).To(gomega.BeEquivalentTo("value"))
 	case <-time.After(time.Second):
@@ -165,8 +166,25 @@ func TestNotifications(t *testing.T) {
 	case notif := <-ch:
 		gomega.Expect(notif.RegistryTitle).To(gomega.BeEquivalentTo("title"))
 		gomega.Expect(notif.Del).To(gomega.BeFalse())
+		gomega.Expect(notif.Update).To(gomega.BeFalse())
 		gomega.Expect(notif.Name).To(gomega.BeEquivalentTo("Name1"))
 		gomega.Expect(notif.Value).To(gomega.BeEquivalentTo("modified"))
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	mapping.Update("Name1", "updated")
+	meta, found = mapping.GetValue("Name1")
+	gomega.Expect(found).To(gomega.BeTrue())
+	gomega.Expect(meta).To(gomega.BeEquivalentTo("updated"))
+
+	select {
+	case notif := <-ch:
+		gomega.Expect(notif.RegistryTitle).To(gomega.BeEquivalentTo("title"))
+		gomega.Expect(notif.Del).To(gomega.BeFalse())
+		gomega.Expect(notif.Update).To(gomega.BeTrue())
+		gomega.Expect(notif.Name).To(gomega.BeEquivalentTo("Name1"))
+		gomega.Expect(notif.Value).To(gomega.BeEquivalentTo("updated"))
 	case <-time.After(time.Second):
 		t.FailNow()
 	}
@@ -180,8 +198,9 @@ func TestNotifications(t *testing.T) {
 	case notif := <-ch:
 		gomega.Expect(notif.RegistryTitle).To(gomega.BeEquivalentTo("title"))
 		gomega.Expect(notif.Del).To(gomega.BeTrue())
+		gomega.Expect(notif.Update).To(gomega.BeFalse())
 		gomega.Expect(notif.Name).To(gomega.BeEquivalentTo("Name1"))
-		gomega.Expect(notif.Value).To(gomega.BeEquivalentTo("modified"))
+		gomega.Expect(notif.Value).To(gomega.BeEquivalentTo("updated"))
 	case <-time.After(time.Second):
 		t.FailNow()
 	}


### PR DESCRIPTION
cherry-picked from https://github.com/ligato/cn-infra/pull/269

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>