### PR TITLE
Allow configuration of grpc socket type

### DIFF
--- a/rpc/grpc/config.go
+++ b/rpc/grpc/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	// Endpoint is an address of GRPC netListener
 	Endpoint string `json:"endpoint"`
 
+	// Type of Socket defaults to "tcp" if unset
+
+	SocketType string `json:"socket-type"`
+
 	// MaxMsgSize returns a ServerOption to set the max message size in bytes for inbound mesages.
 	// If this is not set, gRPC uses the default 4MB.
 	MaxMsgSize int `json:"max-msg-size"`

--- a/rpc/grpc/listen_and_serve.go
+++ b/rpc/grpc/listen_and_serve.go
@@ -35,7 +35,13 @@ func FromExistingServer(listenAndServe ListenAndServe) *Plugin {
 
 // ListenAndServeGRPC starts a netListener.
 func ListenAndServeGRPC(config *Config, grpcServer *grpc.Server) (netListener net.Listener, err error) {
-	netListener, err = net.Listen("tcp", config.Endpoint)
+
+	// Default to tcp socket type of not specified for backward compatibility
+	socketType := config.SocketType
+	if socketType == "" {
+		socketType = "tcp"
+	}
+	netListener, err = net.Listen(socketType, config.Endpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
gRPC allows "unix" and other kinds of non-tcp
socket types.  This patch preserves current behavior
of using "tcp" if not specified in the config, but
extends the config to allow specifying the gRPC
socket type.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>