### PR TITLE
Fix comments for SocketType

### DIFF
--- a/rpc/grpc/config.go
+++ b/rpc/grpc/config.go
@@ -29,8 +29,8 @@ type Config struct {
 	// Endpoint is an address of GRPC netListener
 	Endpoint string `json:"endpoint"`
 
-	// Type of Socket defaults to "tcp" if unset
-
+	// SocketType defaults to "tcp" if unset, and can be set to one of the following values:
+	// "tcp", "tcp4", "tcp6", "unix", "unixpacket"
 	SocketType string `json:"socket-type"`
 
 	// MaxMsgSize returns a ServerOption to set the max message size in bytes for inbound mesages.


### PR DESCRIPTION
PR #273 merged but had a comment to enhance the comment around SocketType.
This adds some verbage there to allow the user to understand what exactly
SocketType can be set to.

Signed-off-by: Kyle Mestery <mestery@mestery.com>