### PR TITLE
Wiring spi and impl

### DIFF
--- a/wiring/doc.go
+++ b/wiring/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wiring contains an SPI for Wirable Plugins and implementations of Helper Function to assist
+// with Wiring plugin dependencies into plugins
+package wiring

--- a/wiring/list_plugins.go
+++ b/wiring/list_plugins.go
@@ -1,0 +1,89 @@
+package wiring
+
+import (
+	"reflect"
+
+	"github.com/ligato/cn-infra/core"
+)
+
+// ListUniquePlugins lists the Unique Plugins in a given Plugin
+// Takes argument *core.Plugin
+// Returns []*core.Plugin
+func ListUniqueNamedPlugins(plugins ...core.Plugin) []*core.NamedPlugin {
+	var res []*core.NamedPlugin
+	uniqueness := map[core.Plugin] /*nil*/ interface{}{}
+	for _, plugin := range plugins {
+
+		// Get and pluginValue
+		pluginValue := reflect.ValueOf(plugin)
+
+		// If the plugin value is a pointer, get a concrete value
+		if pluginValue.Kind() == reflect.Ptr {
+			pluginValue = pluginValue.Elem()
+		}
+
+		// Check for zero value etc with isValid()
+		if !pluginValue.IsValid() {
+			return res
+		}
+
+		// We need the type so we can recurse the *type* and get info about fields like their names, whether they are
+		// exported etc
+		pluginType := pluginValue.Type()
+
+		// If the plugin isn't a Struct... what are we doing here? :)
+		if pluginType.Kind() == reflect.Struct {
+			// Iterate over the Fields in the Struct
+			numField := pluginType.NumField()
+			for i := 0; i < numField; i++ {
+				field := pluginType.Field(i)
+
+				// If its not exported, ignore
+				// PkgPath is empty for exported fields because there is no restriction on which pkg can access them
+				exported := field.PkgPath == ""
+				if !exported {
+					continue
+				}
+
+				// Now we see if any of the values in those fields are actually Plugins
+				// Note, its not enough to inspect the types of those fields
+				// The field type represents what is defined in the Struct, and the Struct
+				// May have a non-plugin interface as its field type
+				// But if the *value* in this particular Struct is a plugin, we need to know that
+				fieldVal := pluginValue.Field(i)
+				// If its a pointer, get the concrete value
+				if fieldVal.Kind() == reflect.Ptr {
+					fieldVal = fieldVal.Elem()
+				}
+				// Check to see if that concrete value is a core.Plugin and not nil
+				// Note: Always check CanAddr() or a Panic can results
+				if fieldVal.CanAddr() {
+					pluginInterface := fieldVal.Addr().Interface()
+					plug, ok := pluginInterface.(core.Plugin)
+					if ok && plug != nil {
+						// Check to see if the plugin is unique, ie we haven't seen it before
+						_, found := uniqueness[plug]
+						if !found {
+							// Note that we have seen this plugin
+							uniqueness[plug] = nil
+							// Append it to the list
+							res = append(res, &core.NamedPlugin{PluginName: core.PluginName(field.Name), Plugin: plug})
+							l := ListUniqueNamedPlugins(plug)
+							// Do a uniqueness check for the
+							for _, np := range l {
+								_, found := uniqueness[np.Plugin]
+								if !found {
+									uniqueness[np.Plugin] = nil
+									res = append(res, np)
+								}
+							}
+
+						}
+					}
+				}
+			}
+
+		}
+	}
+	return res
+}

--- a/wiring/list_plugins_test.go
+++ b/wiring/list_plugins_test.go
@@ -1,0 +1,116 @@
+package wiring
+
+import (
+	"testing"
+
+	"github.com/ligato/cn-infra/core"
+	"github.com/onsi/gomega"
+)
+
+// TestListPluginsPluginNoDeps checks that the plugin containing no fields
+// that would implement Plugin interface (here we miss Close())
+// returns empty slice.
+func TestListPluginsPluginNoDeps(t *testing.T) {
+	gomega.RegisterTestingT(t)
+
+	plugin := &PluginNoDeps{}
+	plugs := ListUniqueNamedPlugins(plugin)
+	t.Log("plugs ", plugs)
+	gomega.Expect(plugs).To(gomega.BeNil())
+}
+
+// TestListPluginsOnePluginInDeps checks that the plugin containing multiple fields
+// but only one of them implementing Plugin interface (other fields miss Close())
+// returns slice with one particular plugin.
+func TestListPluginsOnePluginInDeps(t *testing.T) {
+	gomega.RegisterTestingT(t)
+
+	plugin := &PluginOneDep{}
+	plugs := ListUniqueNamedPlugins(plugin)
+	t.Log("plugs ", plugs)
+	gomega.Expect(plugs).To(gomega.Equal([]*core.NamedPlugin{{
+		core.PluginName("Plugin2"), &plugin.Plugin2}}))
+}
+
+// TestListPluginsOnePluginInDeps checks that the plugin containing multiple fields
+// but only one of them implementing Plugin interface (other fields miss Close())
+// returns slice with one particular plugin.
+func TestListPluginsTwoLevelDeps(t *testing.T) {
+	gomega.RegisterTestingT(t)
+
+	plugin := &PluginTwoLevelDeps{}
+	plugs := ListUniqueNamedPlugins(plugin)
+	t.Log("plugs ", plugs)
+	gomega.Expect(len(plugs)).To(gomega.Equal(3))
+	gomega.Expect(plugs[0]).To(gomega.Equal(&core.NamedPlugin{
+		PluginName: core.PluginName("PluginTwoLevelDep1"),
+		Plugin:     &plugin.PluginTwoLevelDep1}))
+	gomega.Expect(plugs[1]).To(gomega.Equal(&core.NamedPlugin{
+		PluginName: core.PluginName("Plugin2"),
+		Plugin:     &plugin.PluginTwoLevelDep1.Plugin2}))
+	gomega.Expect(plugs[2]).To(gomega.Equal(&core.NamedPlugin{
+		PluginName: core.PluginName("PluginTwoLevelDep2"),
+		Plugin:     &plugin.PluginTwoLevelDep2}))
+}
+
+// PluginNoDeps contains no plugins.
+type PluginNoDeps struct {
+	Plugin1 MissignCloseMethod
+	Plugin2 struct {
+		Dep1B string
+	}
+}
+
+func (*PluginNoDeps) Init() error  { return nil }
+func (*PluginNoDeps) Close() error { return nil }
+
+// PluginOneDep contains one plugin (another is missing Close method).
+type PluginOneDep struct {
+	Plugin1 MissignCloseMethod
+	Plugin2 DummyPlugin
+}
+
+func (*PluginOneDep) Init() error  { return nil }
+func (*PluginOneDep) Close() error { return nil }
+
+type PluginTwoLevelDeps struct {
+	PluginTwoLevelDep1 PluginOneDep
+	PluginTwoLevelDep2 DummyPlugin
+}
+
+func (*PluginTwoLevelDeps) Init() error  { return nil }
+func (*PluginTwoLevelDeps) Close() error { return nil }
+
+// MissignCloseMethod implements only Init() but not Close() method.
+type MissignCloseMethod struct {
+}
+
+// Init does nothing.
+func (*MissignCloseMethod) Init() error {
+	return nil
+}
+
+// DummyPlugin only defines Init() and Close() with empty method bodies.
+type DummyPlugin struct {
+	internalFlag bool
+}
+
+// Init does nothing.
+func (*DummyPlugin) Init() error {
+	return nil
+}
+
+// Close does nothing.
+func (*DummyPlugin) Close() error {
+	return nil
+}
+
+// DummyPlugin only defines Init() and Close() with empty method bodies.
+type DummyPluginDep2 struct {
+	internalFlag bool
+}
+
+// Init does nothing.
+func (*DummyPluginDep2) Init() error {
+	return nil
+}

--- a/wiring/wiring_impl.go
+++ b/wiring/wiring_impl.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wiring
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ligato/cn-infra/core"
+	"github.com/ligato/cn-infra/logging/logrus"
+)
+
+// Convenience method for getting a new agent from a Plugins with
+// Logger logrus.DefaultLogger and MaxStartupTimeout 15* time.Second
+func newAgentFromPlugins(plugins ...*core.NamedPlugin) *core.Agent {
+	return core.NewAgentDeprecated(logrus.DefaultLogger(),
+		15*time.Second,
+		plugins...)
+}
+
+// NamePlugin is a convenience function to create a NamedPlugin from a plugin and a name
+func NamePlugin(plugin core.Plugin, name string) *core.NamedPlugin {
+	return &core.NamedPlugin{
+		PluginName: core.PluginName(name),
+		Plugin:     plugin,
+	}
+}
+
+// ComposeWirings composes a list of Wirings into a single Wiring that will apply them in the order provided
+// This is really really handy when you want to simply mutate the DefaultWiring of a Plugin
+// rather than taking full responsiblity for all of its wiring. Example, you could have a
+// Wiring customWiring that just tweaks a single dependency:
+//
+// wiring := wiring.ComposeWiring(plugin.DefaultWiring,customWiring)
+// plugin.wire(wiring)
+func ComposeWirings(wiring ...Wiring) Wiring {
+	ret := func(plugin core.Plugin) (err error) {
+		for _, v := range wiring {
+			err := v(plugin)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return ret
+}
+
+// NewAgent is a convenience method to create a NewAgent from a plugin that is Named and Wirable
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get an agent with a single simple call:
+//
+// agent,err := wiring.NewAgent(plugin)
+//
+// An agent with a custom wiring for the plugin can be applied with a single simple call:
+//
+// agent,err := wiring.NewAgent(plugin, customWiring)
+func NewAgent(plugin NamedWirablePlugin, wiring ...Wiring) (agent *core.Agent, err error) {
+	if plugin == nil {
+		return nil, fmt.Errorf("Cannot construct an Agent for nil plugin")
+	}
+
+	wiring = append(wiring, plugin.DefaultWiring(false))
+
+	err = plugin.Wire(ComposeWirings(wiring...))
+	if err != nil {
+		return nil, err
+	}
+
+	np := NamePlugin(plugin, plugin.Name())
+	return newAgentFromPlugins(np), err
+}
+
+// EventLoopWithInterrupt is a convenience function to run an EventLoopWithInterupt from a single plugin, provided its Wirable and Named
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get a running EventLoopWithInterupt  in a single simple call:
+//
+// err := wiring.EventLoopWithInterupt(plugin)
+//
+// An EventLoop for a plugin with a custom wiring started with a single simple call:
+//
+// err := wiring.EventLoopWithInterupt(plugin, customWiring)
+//
+func EventLoopWithInterrupt(plugin NamedWirablePlugin, closeChan chan struct{}, wiring ...Wiring) error {
+	agent, err := NewAgent(plugin, wiring...)
+	if err != nil {
+		return err
+	}
+	return core.EventLoopWithInterrupt(agent, closeChan)
+}
+
+// Run is a convenience function to run an EventLoop from a single plugin, provided its Wirable and Named
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get a running MonitorableEventLoopWithInterupt  in a single simple call:
+//
+// readyCh,errCh := wiring.EventLoop(plugin,closeCh)
+//
+// An EventLoop for a plugin with a custom wiring started with a single simple call:
+//
+// readyCh,errCh  := wiring.EventLoop(plugin, closeCh,customWiring)
+func Run(plugin NamedWirablePlugin, closeChan chan struct{}, wiring ...Wiring) (<-chan struct{}, <-chan error) {
+	agent, err := NewAgent(plugin, wiring...)
+	if err != nil {
+		errCh := make(chan error, 1)
+		defer close(errCh)
+		readyCh := make(chan struct{})
+		return readyCh, errCh
+	}
+	return core.Run(agent, closeChan)
+}

--- a/wiring/wiring_impl.go
+++ b/wiring/wiring_impl.go
@@ -81,6 +81,9 @@ func NewAgent(plugin NamedWirablePlugin, wiring ...Wiring) (agent *core.Agent, e
 	}
 
 	np := NamePlugin(plugin, plugin.Name())
+	// Get all Dependent Plugins we need to initialize
+	nps := []*core.NamedPlugin{np}
+	nps = append(nps, ListUniqueNamedPlugins(plugin)...)
 	return newAgentFromPlugins(np), err
 }
 

--- a/wiring/wiring_spi.go
+++ b/wiring/wiring_spi.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wiring
+
+import "github.com/ligato/cn-infra/core"
+
+// Wiring is a function that, when called on a core.Plugin is expected to 'wire'
+// Its dependencies
+type Wiring func(plugin core.Plugin) error
+
+// Wireable implements a Wire function to wire in dependencies using a Wiring
+type Wireable interface {
+	Wire(wiring Wiring) error // nil Wiring should result in a Default Wiring
+	DefaultWiring(overwrite bool) Wiring
+}
+
+// WireablePlugin is a core.Plugin that is also Wireable
+type WireablePlugin interface {
+	core.Plugin
+	Wireable
+}
+
+// Named - A thing is said to be Named if it has a method Name() that returns a string
+type Named interface {
+	Name() string
+}
+
+// NamedWirablePlugin a WireablePlugin is Named if it also implements the Named interface
+type NamedWirablePlugin interface {
+	WireablePlugin
+	Named
+}


### PR DESCRIPTION
Note:  This is build on PR #283 (Provide Async Run), so please review changes to event_loop.go there.

Wiring is a simple concept. A plugin is Wireable if you can call:

plugin.Wire(wiring)

Wiring is just a function:

type Wiring func (core.Plugin) error

that is expected to wire up the plugins dependencies.

A plugin is said to be DefaultWireable if it implements:

func DefaultWiring(overwrite bool) Wiring

so you can call

plugin.Wire(plugin.DefaultWiring(true))

to Wire in all of the plugins dependencies.

Conventionally, this is equivalent to plugin.Wire(nil)

Helper functions are provided to let you quickly get from a Wireable Plugin
to an Agent or running EventLoop

agent, err :=wiring.NewAgent(plugin)

err := wiring.EventLoopWithInterrupt(plugin)

readyCh,errCh = wiring.Run(plugin)

And compose Wirings:

wiring :=  ComposeWirings(wiring1,wiring2, wiring3)


