### PR TITLE
Wiring grpc

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Cisco and/or its affiliates.
+// Copyright (c) 2018 Cisco and/or its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,22 +21,22 @@ import (
 	"time"
 
 	"github.com/ligato/cn-infra/logging/logrus"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestEmptyAgent(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 
 	agent := NewAgent(Inject(), WithTimeout(1*time.Second))
-	gomega.Expect(agent).NotTo(gomega.BeNil())
+	Expect(agent).NotTo(BeNil())
 	err := agent.Start()
-	gomega.Expect(err).To(gomega.BeNil())
+	Expect(err).To(BeNil())
 	err = agent.Stop()
-	gomega.Expect(err).To(gomega.BeNil())
+	Expect(err).To(BeNil())
 }
 
 func TestEventLoopWithInterrupt(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 
 	plugins := []*TestPlugin{{}, {}, {}}
 
@@ -45,9 +45,9 @@ func TestEventLoopWithInterrupt(t *testing.T) {
 		{"Third", plugins[2]}}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeFalse())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeFalse())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeFalse())
+		Expect(p.AfterInitialized()).To(BeFalse())
+		Expect(p.Closed()).To(BeFalse())
 	}
 
 	agent := NewAgentDeprecated(logrus.DefaultLogger(), 100*time.Millisecond, namedPlugins...)
@@ -59,26 +59,26 @@ func TestEventLoopWithInterrupt(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeTrue())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeTrue())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeTrue())
+		Expect(p.AfterInitialized()).To(BeTrue())
+		Expect(p.Closed()).To(BeFalse())
 	}
 	close(closeCh)
 
 	select {
 	case errCh := <-errCh:
-		gomega.Expect(errCh).To(gomega.BeNil())
+		Expect(errCh).To(BeNil())
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()
 	}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Closed()).To(gomega.BeTrue())
+		Expect(p.Closed()).To(BeTrue())
 	}
 }
 
 func TestEventLoopFailInit(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 
 	plugins := []*TestPlugin{{}, {}, NewTestPlugin(true, false, false)}
 
@@ -87,9 +87,9 @@ func TestEventLoopFailInit(t *testing.T) {
 		{"Third", plugins[2]}}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeFalse())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeFalse())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeFalse())
+		Expect(p.AfterInitialized()).To(BeFalse())
+		Expect(p.Closed()).To(BeFalse())
 	}
 
 	agent := NewAgentDeprecated(logrus.DefaultLogger(), 100*time.Millisecond, namedPlugins...)
@@ -101,23 +101,23 @@ func TestEventLoopFailInit(t *testing.T) {
 
 	select {
 	case errCh := <-errCh:
-		gomega.Expect(errCh).NotTo(gomega.BeNil())
+		Expect(errCh).NotTo(BeNil())
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()
 	}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeTrue())
+		Expect(p.Initialized()).To(BeTrue())
 		// initialization failed of a plugin failed, afterInit was not called
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeFalse())
-		gomega.Expect(p.Closed()).To(gomega.BeTrue())
+		Expect(p.AfterInitialized()).To(BeFalse())
+		Expect(p.Closed()).To(BeTrue())
 	}
 	close(closeCh)
 
 }
 
 func TestEventLoopAfterInitFailed(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 
 	plugins := []*TestPlugin{{}, NewTestPlugin(false, true, false), {}}
 
@@ -126,9 +126,9 @@ func TestEventLoopAfterInitFailed(t *testing.T) {
 		{"Third", plugins[2]}}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeFalse())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeFalse())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeFalse())
+		Expect(p.AfterInitialized()).To(BeFalse())
+		Expect(p.Closed()).To(BeFalse())
 	}
 
 	agent := NewAgentDeprecated(logrus.DefaultLogger(), 100*time.Millisecond, namedPlugins...)
@@ -140,26 +140,26 @@ func TestEventLoopAfterInitFailed(t *testing.T) {
 
 	select {
 	case errCh := <-errCh:
-		gomega.Expect(errCh).NotTo(gomega.BeNil())
+		Expect(errCh).NotTo(BeNil())
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()
 	}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeTrue())
-		gomega.Expect(p.Closed()).To(gomega.BeTrue())
+		Expect(p.Initialized()).To(BeTrue())
+		Expect(p.Closed()).To(BeTrue())
 	}
 	close(closeCh)
 
-	gomega.Expect(plugins[0].AfterInitialized()).To(gomega.BeTrue())
-	gomega.Expect(plugins[1].AfterInitialized()).To(gomega.BeTrue())
+	Expect(plugins[0].AfterInitialized()).To(BeTrue())
+	Expect(plugins[1].AfterInitialized()).To(BeTrue())
 	// afterInit of the second plugin failed thus the third was not afterInitialized
-	gomega.Expect(plugins[2].AfterInitialized()).To(gomega.BeFalse())
+	Expect(plugins[2].AfterInitialized()).To(BeFalse())
 
 }
 
 func TestEventLoopCloseFailed(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 
 	plugins := []*TestPlugin{NewTestPlugin(false, false, true), {}, {}}
 
@@ -168,9 +168,9 @@ func TestEventLoopCloseFailed(t *testing.T) {
 		{"Third", plugins[2]}}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeFalse())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeFalse())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeFalse())
+		Expect(p.AfterInitialized()).To(BeFalse())
+		Expect(p.Closed()).To(BeFalse())
 	}
 
 	agent := NewAgentDeprecated(logrus.DefaultLogger(), 100*time.Millisecond, namedPlugins...)
@@ -182,33 +182,33 @@ func TestEventLoopCloseFailed(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	for _, p := range plugins {
-		gomega.Expect(p.Initialized()).To(gomega.BeTrue())
-		gomega.Expect(p.AfterInitialized()).To(gomega.BeTrue())
-		gomega.Expect(p.Closed()).To(gomega.BeFalse())
+		Expect(p.Initialized()).To(BeTrue())
+		Expect(p.AfterInitialized()).To(BeTrue())
+		Expect(p.Closed()).To(BeFalse())
 	}
 
 	close(closeCh)
 
 	select {
 	case errCh := <-errCh:
-		gomega.Expect(errCh).NotTo(gomega.BeNil())
+		Expect(errCh).NotTo(BeNil())
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()
 	}
 
 	for _, p := range plugins {
-		gomega.Expect(p.Closed()).To(gomega.BeTrue())
+		Expect(p.Closed()).To(BeTrue())
 	}
 
 }
 
 func TestPluginApi(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 	const plName = "Name"
 	named := NamedPlugin{plName, &TestPlugin{}}
 
 	strRep := named.String()
-	gomega.Expect(strRep).To(gomega.BeEquivalentTo(plName))
+	Expect(strRep).To(BeEquivalentTo(plName))
 }
 
 type TestPlugin struct {

--- a/rpc/grpc/wiring_impl.go
+++ b/rpc/grpc/wiring_impl.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"fmt"
+
+	"github.com/ligato/cn-infra/config"
+	"github.com/ligato/cn-infra/core"
+	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/logging/logrus"
+	"github.com/ligato/cn-infra/wiring"
+)
+
+const (
+	defaultName = "grpc"
+	packageName = "grpc"
+)
+
+// Wire implements wiring.Wireable allowing us to use Wiring rather than Flavors
+// to configure Plugin Dependencies.
+func (plugin *Plugin) Wire(wiring wiring.Wiring) error {
+	if wiring == nil {
+		wiring = plugin.DefaultWiring(false)
+	}
+	err := wiring(plugin)
+	return err
+}
+
+// DefaultWiring implements wiring.DefaultWirable allowing us to get a fully wired version of this file
+// without having to specify any wiring.
+func (plugin *Plugin) DefaultWiring(overwrite bool) wiring.Wiring {
+	return DefaultWiring(overwrite)
+}
+
+// Name implement wiring.Named
+func (plugin *Plugin) Name() string {
+	return string(plugin.Deps.PluginName)
+}
+
+// IsWired returns true if all mandatory dependencies for the plugin have usable value
+func (plugin *Plugin) IsWired() bool {
+	return plugin.Log != nil && plugin.PluginName != "" && plugin.PluginConfig != nil
+}
+
+// DefaultWiring creates a DefaultWiring for the Plugin.  If overwrite is true, it will overwrite any exiting
+// dependencies with Default values.  If overwrite is false, any already set dependency will be unchanged
+func DefaultWiring(overwrite bool) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+
+		p, ok := plugin.(*Plugin)
+		if ok {
+			if err := p.Wire(WithName(overwrite)); err != nil {
+				return err
+			}
+			if err := p.Wire(WithLog(overwrite)); err != nil {
+				return err
+			}
+			if err := p.Wire(WithPluginConfig(overwrite)); err != nil {
+				return err
+			}
+			return nil
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}
+
+// WithLog returns a wiring that sets the Log dependency of the Plugin
+// If overwrite is false, WithLog will leave unchanged any existing Log wired in
+// If a log value is provided, it will be wired in, otherwise, a default will be
+// generated and wired in
+func WithLog(overwrite bool, log ...logging.PluginLogger) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+		p, ok := plugin.(*Plugin)
+		if ok {
+			if overwrite || p.Log == nil {
+				if len(log) > 0 {
+					p.Log = log[0]
+				} else {
+					p.Log = logging.ForPlugin(p.Name(), logrus.NewLogRegistry())
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}
+
+// WithLogFactory wires a Log dependency generated from the LogFactory (if one is provided)
+// If overwrite is false, existing values will not be overwritten
+// If a factory is provided, it will be used, otherwise, a default LogFactory will be generated and used
+func WithLogFactory(overwrite bool, factory ...logging.LogFactory) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+		p, ok := plugin.(*Plugin)
+		if ok {
+			err := p.Wire(WithLog(overwrite, logging.ForPlugin(p.Name(), logrus.NewLogRegistry())))
+			return err
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}
+
+// WithName wires a PluginName for the Plugin
+// If overwrite is false, existing values will not be overwritten
+// If name is provided, that will be configured as the PluginName, otherwise a default will be used
+func WithName(overwrite bool, name ...string) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+		p, ok := plugin.(*Plugin)
+		if ok {
+			if overwrite || p.PluginName == "" {
+				if len(name) > 0 {
+					p.PluginName = core.PluginName(name[0])
+				} else {
+					p.PluginName = core.PluginName(defaultName)
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}
+
+// WithPluginConfig wires in a PluginConfig for the plugin
+// If overwrite is false, existing values will not be overwritten
+// If cfg is provided, that will be configured as the PluginConfig, otherwise a default will be used
+func WithPluginConfig(overwrite bool, cfg ...config.PluginConfig) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+		p, ok := plugin.(*Plugin)
+		if ok {
+			if len(cfg) > 0 {
+				p.PluginConfig = cfg[0]
+			} else {
+				if err := p.Wire(WithName(false)); err != nil {
+					return err
+				}
+				if overwrite || p.PluginConfig == nil {
+					p.PluginConfig = config.ForPlugin(p.Name())
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}

--- a/rpc/grpc/wiring_impl.go
+++ b/rpc/grpc/wiring_impl.go
@@ -136,6 +136,26 @@ func WithName(overwrite bool, name ...string) wiring.Wiring {
 	return ret
 }
 
+// WithNamePrefix wires a PluginName for the Plugin
+// If overwrite is false, existing values will not be overwritten
+// If name is provided, that will be configured as the prefix to PluginName
+func WithNamePrefix(overwrite bool, name ...string) wiring.Wiring {
+	ret := func(plugin core.Plugin) error {
+		p, ok := plugin.(*Plugin)
+		if ok {
+			if overwrite || p.PluginName == "" {
+				p.Wire(WithName(false)) // Make sure worst case we have the Default name
+				if len(name) > 0 {
+					p.PluginName = core.PluginName(name[0] + string(p.PluginName))
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("Could not convert core.Plugin to *%s.Plugin", packageName)
+	}
+	return ret
+}
+
 // WithPluginConfig wires in a PluginConfig for the plugin
 // If overwrite is false, existing values will not be overwritten
 // If cfg is provided, that will be configured as the PluginConfig, otherwise a default will be used

--- a/rpc/grpc/wiring_test.go
+++ b/rpc/grpc/wiring_test.go
@@ -15,119 +15,87 @@
 package grpc
 
 import (
-	"github.com/ligato/cn-infra/core"
+	"testing"
+
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/logging/logrus"
-	"testing"
+	"github.com/onsi/gomega"
 )
 
 func Test01DefaultWiring(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	err := plugin.Wire(plugin.DefaultWiring(true))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.PluginName != core.PluginName(defaultName) {
-		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
-	}
-	if plugin.Log == nil {
-		t.Errorf("Incorrect Log, expected non-nil, got nil")
-	}
-	if plugin.PluginConfig == nil {
-		t.Errorf("Incorrect PluginConfig, expected non-nil got nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(defaultName))
+	gomega.Expect(plugin.Log).ShouldNot(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).ShouldNot(gomega.BeNil())
 }
 
 func Test02WithNameDefault(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	err := plugin.Wire(WithName(true))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.PluginName != core.PluginName(defaultName) {
-		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
-	}
-
-	if plugin.Log != nil {
-		t.Errorf("Incorrect Log, expected nil, actual non-nil")
-	}
-
-	if plugin.PluginConfig != nil {
-		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(defaultName))
+	gomega.Expect(plugin.Log).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).Should(gomega.BeNil())
 }
 
 func Test03WithNameNonDefault(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	name := "foo"
 	err := plugin.Wire(WithName(true, name))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.PluginName != core.PluginName(name) {
-		t.Errorf("Incorrect PluginName, expected %s, actual: %s", name, string(plugin.PluginName))
-	}
-	if plugin.Log != nil {
-		t.Errorf("Incorrect Log, expected nil, actual non-nil")
-	}
-	if plugin.PluginConfig != nil {
-		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(name))
+	gomega.Expect(plugin.Log).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).Should(gomega.BeNil())
 }
 
 func Test04WithLogNonDefault(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	log := logging.ForPlugin(defaultName, logrus.NewLogRegistry())
 	err := plugin.Wire(WithLog(true, log))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.Log != log {
-		t.Errorf("Incorrect Log, expected %s, actual %s", log, plugin.Log)
-	}
-	if plugin.PluginConfig != nil {
-		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.Log).Should(gomega.BeEquivalentTo(log))
+	gomega.Expect(plugin.PluginConfig).Should(gomega.BeNil())
 }
 
 func Test05NilWiring(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	err := plugin.Wire(nil)
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.PluginName != core.PluginName(defaultName) {
-		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
-	}
-	if plugin.Log == nil {
-		t.Errorf("Incorrect Log, expected non-nil, got nil")
-	}
-	if plugin.PluginConfig == nil {
-		t.Errorf("Incorrect PluginConfig, expected non-nil got nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(defaultName))
+	gomega.Expect(plugin.Log).ShouldNot(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).ShouldNot(gomega.BeNil())
 }
 
 func Test06DefaultWiringOverwriteTrue(t *testing.T) {
+	gomega.RegisterTestingT(t)
 	plugin := &Plugin{}
 	name := "foo"
 
 	err := plugin.Wire(WithName(true, name))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
 
 	err = plugin.Wire(DefaultWiring(false))
-	if err != nil {
-		t.Errorf("plugin.Wire returned error %s", err)
-	}
-	if plugin.PluginName != core.PluginName(name) {
-		t.Errorf("Incorrect PluginName, expected %s, actual: %s", name, string(plugin.PluginName))
-	}
-	if plugin.Log == nil {
-		t.Errorf("Incorrect Log, expected non-nil, actual nil")
-	}
-	if plugin.PluginConfig == nil {
-		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
-	}
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(defaultName))
+	gomega.Expect(plugin.Log).ShouldNot(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).ShouldNot(gomega.BeNil())
 
+}
+
+func Test07WithNamePrefix(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	plugin := &Plugin{}
+	name := "foo"
+	err := plugin.Wire(WithNamePrefix(true, name))
+	gomega.Expect(err).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginName).Should(gomega.BeEquivalentTo(name + defaultName))
+	gomega.Expect(plugin.Log).Should(gomega.BeNil())
+	gomega.Expect(plugin.PluginConfig).Should(gomega.BeNil())
 }

--- a/rpc/grpc/wiring_test.go
+++ b/rpc/grpc/wiring_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"github.com/ligato/cn-infra/core"
+	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/logging/logrus"
+	"testing"
+)
+
+func Test01DefaultWiring(t *testing.T) {
+	plugin := &Plugin{}
+	err := plugin.Wire(plugin.DefaultWiring(true))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.PluginName != core.PluginName(defaultName) {
+		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
+	}
+	if plugin.Log == nil {
+		t.Errorf("Incorrect Log, expected non-nil, got nil")
+	}
+	if plugin.PluginConfig == nil {
+		t.Errorf("Incorrect PluginConfig, expected non-nil got nil")
+	}
+}
+
+func Test02WithNameDefault(t *testing.T) {
+	plugin := &Plugin{}
+	err := plugin.Wire(WithName(true))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.PluginName != core.PluginName(defaultName) {
+		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
+	}
+
+	if plugin.Log != nil {
+		t.Errorf("Incorrect Log, expected nil, actual non-nil")
+	}
+
+	if plugin.PluginConfig != nil {
+		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
+	}
+}
+
+func Test03WithNameNonDefault(t *testing.T) {
+	plugin := &Plugin{}
+	name := "foo"
+	err := plugin.Wire(WithName(true, name))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.PluginName != core.PluginName(name) {
+		t.Errorf("Incorrect PluginName, expected %s, actual: %s", name, string(plugin.PluginName))
+	}
+	if plugin.Log != nil {
+		t.Errorf("Incorrect Log, expected nil, actual non-nil")
+	}
+	if plugin.PluginConfig != nil {
+		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
+	}
+}
+
+func Test04WithLogNonDefault(t *testing.T) {
+	plugin := &Plugin{}
+	log := logging.ForPlugin(defaultName, logrus.NewLogRegistry())
+	err := plugin.Wire(WithLog(true, log))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.Log != log {
+		t.Errorf("Incorrect Log, expected %s, actual %s", log, plugin.Log)
+	}
+	if plugin.PluginConfig != nil {
+		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
+	}
+}
+
+func Test05NilWiring(t *testing.T) {
+	plugin := &Plugin{}
+	err := plugin.Wire(nil)
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.PluginName != core.PluginName(defaultName) {
+		t.Errorf("Incorrect PluginName, expected %s, actual: %s", defaultName, string(plugin.PluginName))
+	}
+	if plugin.Log == nil {
+		t.Errorf("Incorrect Log, expected non-nil, got nil")
+	}
+	if plugin.PluginConfig == nil {
+		t.Errorf("Incorrect PluginConfig, expected non-nil got nil")
+	}
+}
+
+func Test06DefaultWiringOverwriteTrue(t *testing.T) {
+	plugin := &Plugin{}
+	name := "foo"
+
+	err := plugin.Wire(WithName(true, name))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+
+	err = plugin.Wire(DefaultWiring(false))
+	if err != nil {
+		t.Errorf("plugin.Wire returned error %s", err)
+	}
+	if plugin.PluginName != core.PluginName(name) {
+		t.Errorf("Incorrect PluginName, expected %s, actual: %s", name, string(plugin.PluginName))
+	}
+	if plugin.Log == nil {
+		t.Errorf("Incorrect Log, expected non-nil, actual nil")
+	}
+	if plugin.PluginConfig == nil {
+		t.Errorf("Incorrect PluginConfig, expected nil actual non-nil")
+	}
+
+}

--- a/wiring/doc.go
+++ b/wiring/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wiring contains an SPI for Wirable Plugins and implementations of Helper Function to assist
+// with Wiring plugin dependencies into plugins
+package wiring

--- a/wiring/wiring_impl.go
+++ b/wiring/wiring_impl.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wiring
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ligato/cn-infra/core"
+	"github.com/ligato/cn-infra/logging/logrus"
+)
+
+// Convenience method for getting a new agent from a Plugins with
+// Logger logrus.DefaultLogger and MaxStartupTimeout 15* time.Second
+func newAgentFromPlugins(plugins ...*core.NamedPlugin) *core.Agent {
+	return core.NewAgentDeprecated(logrus.DefaultLogger(),
+		15*time.Second,
+		plugins...)
+}
+
+// NamePlugin is a convenience function to create a NamedPlugin from a plugin and a name
+func NamePlugin(plugin core.Plugin, name string) *core.NamedPlugin {
+	return &core.NamedPlugin{
+		PluginName: core.PluginName(name),
+		Plugin:     plugin,
+	}
+}
+
+// ComposeWirings composes a list of Wirings into a single Wiring that will apply them in the order provided
+// This is really really handy when you want to simply mutate the DefaultWiring of a Plugin
+// rather than taking full responsiblity for all of its wiring. Example, you could have a
+// Wiring customWiring that just tweaks a single dependency:
+//
+// wiring := wiring.ComposeWiring(plugin.DefaultWiring,customWiring)
+// plugin.wire(wiring)
+func ComposeWirings(wiring ...Wiring) Wiring {
+	ret := func(plugin core.Plugin) (err error) {
+		for _, v := range wiring {
+			err := v(plugin)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return ret
+}
+
+// NewAgent is a convenience method to create a NewAgent from a plugin that is Named and Wirable
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get an agent with a single simple call:
+//
+// agent,err := wiring.NewAgent(plugin)
+//
+// An agent with a custom wiring for the plugin can be applied with a single simple call:
+//
+// agent,err := wiring.NewAgent(plugin, customWiring)
+func NewAgent(plugin NamedWirablePlugin, wiring ...Wiring) (agent *core.Agent, err error) {
+	if plugin == nil {
+		return nil, fmt.Errorf("Cannot construct an Agent for nil plugin")
+	}
+
+	wiring = append(wiring, plugin.DefaultWiring(false))
+
+	err = plugin.Wire(ComposeWirings(wiring...))
+	if err != nil {
+		return nil, err
+	}
+
+	np := NamePlugin(plugin, plugin.Name())
+	return newAgentFromPlugins(np), err
+}
+
+// EventLoopWithInterrupt is a convenience function to run an EventLoopWithInterupt from a single plugin, provided its Wirable and Named
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get a running EventLoopWithInterupt  in a single simple call:
+//
+// err := wiring.EventLoopWithInterupt(plugin)
+//
+// An EventLoop for a plugin with a custom wiring started with a single simple call:
+//
+// err := wiring.EventLoopWithInterupt(plugin, customWiring)
+//
+func EventLoopWithInterrupt(plugin NamedWirablePlugin, closeChan chan struct{}, wiring ...Wiring) error {
+	agent, err := NewAgent(plugin, wiring...)
+	if err != nil {
+		return err
+	}
+	return core.EventLoopWithInterrupt(agent, closeChan)
+}
+
+// Run is a convenience function to run an EventLoop from a single plugin, provided its Wirable and Named
+// Optionally you can provide a list of wirings to be composed an applied to the plugin
+// If no wirings are provided and the plugin is DefaultWirable, the DefaultWiring will be
+// applied.  This lets you get a running MonitorableEventLoopWithInterupt  in a single simple call:
+//
+// readyCh,errCh := wiring.EventLoop(plugin,closeCh)
+//
+// An EventLoop for a plugin with a custom wiring started with a single simple call:
+//
+// readyCh,errCh  := wiring.EventLoop(plugin, closeCh,customWiring)
+func Run(plugin NamedWirablePlugin, closeChan chan struct{}, wiring ...Wiring) (<-chan struct{}, <-chan error) {
+	agent, err := NewAgent(plugin, wiring...)
+	if err != nil {
+		errCh := make(chan error, 1)
+		defer close(errCh)
+		readyCh := make(chan struct{})
+		return readyCh, errCh
+	}
+	return core.Run(agent, closeChan)
+}

--- a/wiring/wiring_spi.go
+++ b/wiring/wiring_spi.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wiring
+
+import "github.com/ligato/cn-infra/core"
+
+// Wiring is a function that, when called on a core.Plugin is expected to 'wire'
+// Its dependencies
+type Wiring func(plugin core.Plugin) error
+
+// Wireable implements a Wire function to wire in dependencies using a Wiring
+type Wireable interface {
+	Wire(wiring Wiring) error // nil Wiring should result in a Default Wiring
+	DefaultWiring(overwrite bool) Wiring
+}
+
+// WireablePlugin is a core.Plugin that is also Wireable
+type WireablePlugin interface {
+	core.Plugin
+	Wireable
+}
+
+// Named - A thing is said to be Named if it has a method Name() that returns a string
+type Named interface {
+	Name() string
+}
+
+// NamedWirablePlugin a WireablePlugin is Named if it also implements the Named interface
+type NamedWirablePlugin interface {
+	WireablePlugin
+	Named
+}


### PR DESCRIPTION
Add Wiring to grpc Plugin and tests
    
    Note: event_loop.go here is from PR #283, please
    review changes  there.
    
    wiring/* is from PR #288, please review changes there.
    
    This PR is only really about the changes to rpc/grpc
    
    The only parts of this change that are required for
    Wiring are
    
    plugin.Wire()
    and
    plugin.DefaultWiring(bool)
    
    All of the 'WithXYZ(bool)' functions are optional but:
    
    a) Radically improve usability
    b) Radically simplify testing
