### PR TITLE
Implement Walk for plugins

### DIFF
--- a/utils/pluginutils/walk_impl.go
+++ b/utils/pluginutils/walk_impl.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginutils
+
+import (
+	"reflect"
+
+	"fmt"
+
+	"github.com/ligato/cn-infra/core"
+)
+
+const (
+	invalidValueErrorString = "Invalid value: %s"
+)
+
+type WalkFunc func(core.Plugin) error
+
+// Walk runs WalkFunc f on all descendants of
+func Walk(plugin core.Plugin, f WalkFunc) error {
+	err := f(plugin)
+	if err != nil {
+		return err
+	}
+	// Get and pluginValue
+	pluginValue := reflect.ValueOf(plugin)
+
+	// If the plugin value is a pointer, get a concrete value
+	if pluginValue.Kind() == reflect.Ptr {
+		pluginValue = pluginValue.Elem()
+	}
+
+	// Check for zero value etc with isValid()
+	if !pluginValue.IsValid() {
+		return fmt.Errorf(invalidValueErrorString, pluginValue)
+	}
+
+	// We need the type so we can recurse the *type* and get info about fields like their names, whether they are
+	// exported etc
+	pluginType := pluginValue.Type()
+
+	// If the plugin isn't a Struct... what are we doing here? :)
+	if pluginType.Kind() == reflect.Struct {
+		// Iterate over the Fields in the Struct
+		numField := pluginType.NumField()
+		for i := 0; i < numField; i++ {
+			field := pluginType.Field(i)
+
+			// If its not exported, ignore
+			// PkgPath is empty for exported fields because there is no restriction on which pkg can access them
+			exported := field.PkgPath == ""
+			if !exported {
+				continue
+			}
+
+			// Now we see if any of the values in those fields are actually Plugins
+			// Note, its not enough to inspect the types of those fields
+			// The field type represents what is defined in the Struct, and the Struct
+			// May have a non-plugin interface as its field type
+			// But if the *value* in this particular Struct is a plugin, we need to know that
+			fieldVal := pluginValue.Field(i)
+			// If its a pointer, get the concrete value
+			if fieldVal.Kind() == reflect.Ptr {
+				fieldVal = fieldVal.Elem()
+			}
+			// Check to see if that concrete value is a core.Plugin and not nil
+			// Note: Always check CanAddr() or a Panic can results
+			if fieldVal.CanAddr() {
+				pluginInterface := fieldVal.Addr().Interface()
+				plug, ok := pluginInterface.(core.Plugin)
+				if ok && plug != nil {
+					return Walk(plug, f)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type List struct {
+	Plugins []core.Plugin
+}
+
+func (pl *List) WalkFunc(plugin core.Plugin) error {
+	pl.Plugins = append(pl.Plugins, plugin)
+	return nil
+}

--- a/utils/pluginutils/walk_test.go
+++ b/utils/pluginutils/walk_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginutils_test
+
+import (
+	"testing"
+
+	"github.com/ligato/cn-infra/utils/pluginutils"
+	. "github.com/onsi/gomega"
+)
+
+//func TestFilter(t *testing.T) {
+//	gomega.RegisterTestingT(t)
+//	plugins := []core.Plugin{&Plugin{}, &Plugin{name: "foo"}, &Plugin{}, &Plugin{}}
+//	plugin.Filter(plugins, func(plugin core.Plugin) bool {
+//		return plugin.name == "foo"
+//	})
+//}
+
+// TestDescendantsNoDeps checks that the plugin containing no fields
+// that would implement Plugin interface (here we miss Close())
+// returns empty slice.
+func TestWalkNoDeps(t *testing.T) {
+	RegisterTestingT(t)
+
+	p := &Plugin{}
+	pl := &pluginutils.List{}
+	err := pluginutils.Walk(p, pl.WalkFunc)
+	Expect(err).To(BeNil())
+	Expect(len(pl.Plugins)).To(Equal(1))
+	Expect(pl.Plugins[0]).To(Equal(p))
+}
+
+// TestDescendantsInDeps checks that the plugin containing multiple fields
+// but only one of them implementing Plugin interface (other fields miss Close())
+// returns slice with one particular plugin.
+func TestWalkOneLevel(t *testing.T) {
+	RegisterTestingT(t)
+
+	p := &PluginOneDep{}
+	pl := pluginutils.List{}
+	err := pluginutils.Walk(p, pl.WalkFunc)
+	Expect(err).To(BeNil())
+	Expect(len(pl.Plugins)).To(Equal(2))
+	Expect(pl.Plugins[0]).To(Equal(p))
+	Expect(pl.Plugins[1]).To(Equal(&p.Plugin2))
+}
+
+// TestDescendantsTwoLevelDeps checks that the plugin containing multiple fields
+// but only one of them implementing Plugin interface (other fields miss Close())
+// returns slice with one particular plugin.
+func TestWalkTwoLevel(t *testing.T) {
+	RegisterTestingT(t)
+
+	p := &PluginTwoLevel{}
+	pl := pluginutils.List{}
+	err := pluginutils.Walk(p, pl.WalkFunc)
+	Expect(err).To(BeNil())
+	Expect(len(pl.Plugins)).To(Equal(4))
+	Expect(pl.Plugins[0]).To(Equal(p))
+	Expect(pl.Plugins[1]).Should(Equal(&p.PluginTwoLevelDep1))
+	Expect(pl.Plugins[2]).Should(Equal(&p.PluginTwoLevelDep2))
+	Expect(pl.Plugins[3]).Should(Equal(&p.PluginTwoLevelDep1.Plugin2))
+}
+
+// Plugin contains no plugins.
+type Plugin struct {
+	Plugin1 NotAPlugin
+	Plugin2 struct {
+		Dep1B string
+	}
+}
+
+func (*Plugin) Init() error  { return nil }
+func (*Plugin) Close() error { return nil }
+
+// PluginOneDep contains one plugin (another is missing Close method).
+type PluginOneDep struct {
+	DepOneLevel
+}
+
+type DepOneLevel struct {
+	Plugin1 NotAPlugin
+	Plugin2 Plugin
+}
+
+func (*PluginOneDep) Init() error  { return nil }
+func (*PluginOneDep) Close() error { return nil }
+
+type PluginTwoLevel struct {
+	PluginTwoLevelDep1 PluginOneDep
+	PluginTwoLevelDep2 Plugin
+}
+
+func (*PluginTwoLevel) Init() error  { return nil }
+func (*PluginTwoLevel) Close() error { return nil }
+
+// NotAPlugin implements only Init() but not Close() method.
+type NotAPlugin struct {
+}
+
+// Init does nothing.
+func (*NotAPlugin) Init() error {
+	return nil
+}


### PR DESCRIPTION
This is not yet ready.

The intended final state is inspired by:
https://golang.org/pkg/path/filepath/#Walk

It basically consists of a function:
func Walk(core.Plugin,WalkFunc) error

Where
type Walkfunc func(core.Plugin) error

The idea would be that we could have WalkFunc like
List
Init
AfterInit
Close

That would walk down the plugin tree.  This would be instead
of the newly proposed options.Recursive.

Now, for what isn't right yet.
We have this really awesome pattern where we use Dep
to express our Dependencies and embed it in our Plugin.
Unfortunately, Dep is not a Plugin, so if you just walk down the trees
of things that are Plugins... that won't work.
So you actually have to walk the entire tree *looking* for Plugins

Note: the newly proposed options.Resurcive has exactly the same
problem.

I'm putting this out there just so folks can see what I'm thinking
even though its not done yet.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>