### PR TITLE
Cleanup PrevRev on resync

### DIFF
--- a/datasync/syncbase/prev_revisions.go
+++ b/datasync/syncbase/prev_revisions.go
@@ -132,3 +132,11 @@ func (r *PrevRevisions) ListKeys() []string {
 
 	return ret
 }
+
+// Cleanup removes all data from the registry
+func (r *PrevRevisions) Cleanup() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.revisions = map[string]datasync.LazyValueWithRev{}
+}

--- a/datasync/syncbase/watcher.go
+++ b/datasync/syncbase/watcher.go
@@ -153,6 +153,7 @@ func (adapter *Registry) PropagateChanges(txData map[string]datasync.ChangeValue
 
 // PropagateResync fills registered channels with the data.
 func (adapter *Registry) PropagateResync(txData map[string]datasync.ChangeValue) error {
+	adapter.lastRev.Cleanup()
 	for _, sub := range adapter.subscriptions {
 		resyncEv := NewResyncEventDB(map[string]datasync.KeyValIterator{})
 


### PR DESCRIPTION
When resync is triggered prevRev must be cleaned. Otherwise subsequent changes might contain invalid prevValues. The reason why we have never come accross this behavior yet is that the resync is triggered only at startup. In that case prevRev is empty anyway.