### PR TITLE
idxmap: expose secondary fields (to be used by KVScheduler)

### DIFF
--- a/idxmap/api.go
+++ b/idxmap/api.go
@@ -38,7 +38,7 @@ type NamedMapping interface {
 
 	// ListFields returns a map of fields (secondary indexes) and their values
 	// currently associated with the item identified by <name>.
-	ListFields(name string) map[string] /* field */ []string /* values */
+	ListFields(name string) map[string][]string // field -> values
 
 	// Watch subscribes to receive notifications about the changes in the
 	// mapping. To receive changes through a channel, ToChan utility can be used.

--- a/idxmap/api.go
+++ b/idxmap/api.go
@@ -14,10 +14,6 @@
 
 package idxmap
 
-import (
-	"github.com/ligato/cn-infra/core"
-)
-
 // NamedMapping is the "user API" to the mapping. It provides read-only access.
 type NamedMapping interface {
 	// GetRegistryTitle returns the title assigned to the registry.
@@ -49,7 +45,7 @@ type NamedMapping interface {
 	//
 	//  map.Watch(plugin.PluginName, func(msgNamedMappingGenericEvent) {/*handle callback*/ return nil})
 	//
-	Watch(subscriber core.PluginName, callback func(NamedMappingGenericEvent)) error
+	Watch(subscriber string, callback func(NamedMappingGenericEvent)) error
 }
 
 // NamedMappingRW is the "owner API" to the mapping. Using this API the owner

--- a/idxmap/api.go
+++ b/idxmap/api.go
@@ -36,6 +36,10 @@ type NamedMapping interface {
 	// ListAllNames returns all names in the mapping.
 	ListAllNames() (names []string)
 
+	// ListFields returns a map of fields (secondary indexes) and their values
+	// currently associated with the item identified by <name>.
+	ListFields(name string) map[string] /* field */ []string /* values */
+
 	// Watch subscribes to receive notifications about the changes in the
 	// mapping. To receive changes through a channel, ToChan utility can be used.
 	//

--- a/idxmap/mem/inmemory_name_mapping.go
+++ b/idxmap/mem/inmemory_name_mapping.go
@@ -131,6 +131,27 @@ func (mem *memNamedMapping) ListAllNames() (names []string) {
 	return ret
 }
 
+// ListFields returns a map of fields (secondary indexes) and their values
+// currently associated with the item identified by <name>.
+func (mem *memNamedMapping) ListFields(name string) map[string][]string {
+	mem.access.RLock()
+	defer mem.access.RUnlock()
+
+	fields := make(map[string][]string)
+
+	item, found := mem.nameToIdx[name]
+	if found {
+		for field := range item.indexed {
+			fields[field] = []string{}
+			for _, value := range item.indexed[field] {
+				fields[field] = append(fields[field], value)
+			}
+		}
+	}
+
+	return fields
+}
+
 // ListNames looks up the items by secondary indexes. It returns all
 // names matching the selection.
 func (mem *memNamedMapping) ListNames(field string, value string) []string {

--- a/idxmap/mem/inmemory_name_mapping.go
+++ b/idxmap/mem/inmemory_name_mapping.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ligato/cn-infra/core"
 	"github.com/ligato/cn-infra/idxmap"
 	"github.com/ligato/cn-infra/logging"
 )
+
+// IndexFunction should return map field->values for a given item.
+type IndexFunction func(item interface{}) map[string][]string
 
 // mappingItem represents single item stored in mapping.
 type mappingItem struct {
@@ -40,11 +42,11 @@ type memNamedMapping struct {
 	access    sync.RWMutex
 	nameToIdx map[string]*mappingItem
 	// createIndexes is function that computes secondary indexes for a given item.
-	createIndexes func(interface{}) map[string][]string
+	createIndexes IndexFunction
 	// indexes is a register of secondary indexes
 	indexes map[string] /* index name */ map[string] /* index value */ *nameSet
 	// subscribers to whom notifications are delivered
-	subscribers sync.Map //map[core.PluginName]func(idxmap.NamedMappingGenericEvent)
+	subscribers sync.Map //map[string]func(idxmap.NamedMappingGenericEvent)
 	title       string
 }
 
@@ -53,7 +55,7 @@ type memNamedMapping struct {
 // An index function that builds secondary indexes for an item can be defined
 // and passed as <indexFunction>.
 func NewNamedMapping(logger logging.Logger, title string,
-	indexFunction func(interface{}) map[string][]string) idxmap.NamedMappingRW {
+	indexFunction IndexFunction) idxmap.NamedMappingRW {
 	mem := memNamedMapping{}
 	mem.Logger = logger
 	mem.nameToIdx = map[string]*mappingItem{}
@@ -173,7 +175,7 @@ func (mem *memNamedMapping) ListNames(field string, value string) []string {
 
 // Watch allows to subscribe for tracking changes in the mapping.
 // When an item is added or removed, the given <callback> is triggered.
-func (mem *memNamedMapping) Watch(subscriber core.PluginName, callback func(idxmap.NamedMappingGenericEvent)) error {
+func (mem *memNamedMapping) Watch(subscriber string, callback func(idxmap.NamedMappingGenericEvent)) error {
 	mem.Debug("Watch ", subscriber)
 
 	_, found := mem.subscribers.LoadOrStore(subscriber, callback)
@@ -259,7 +261,7 @@ func (mem *memNamedMapping) putNameToIdxSync(name string, metadata interface{}) 
 
 func (mem *memNamedMapping) publishAddToChannel(name string, value interface{}) {
 	mem.subscribers.Range(func(key, val interface{}) bool {
-		subscriber := key.(core.PluginName)
+		subscriber := key.(string)
 		clb := val.(func(idxmap.NamedMappingGenericEvent))
 
 		if clb != nil {
@@ -282,7 +284,7 @@ func (mem *memNamedMapping) publishAddToChannel(name string, value interface{}) 
 
 func (mem *memNamedMapping) publishUpdateToChannel(name string, value interface{}) {
 	mem.subscribers.Range(func(key, val interface{}) bool {
-		subscriber := key.(core.PluginName)
+		subscriber := key.(string)
 		clb := val.(func(idxmap.NamedMappingGenericEvent))
 
 		if clb != nil {
@@ -305,7 +307,7 @@ func (mem *memNamedMapping) publishUpdateToChannel(name string, value interface{
 
 func (mem *memNamedMapping) publishDelToChannel(name string, value interface{}) {
 	mem.subscribers.Range(func(key, val interface{}) bool {
-		subscriber := key.(core.PluginName)
+		subscriber := key.(string)
 		clb := val.(func(idxmap.NamedMappingGenericEvent))
 
 		if clb != nil {


### PR DESCRIPTION
Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>