### PR TITLE
Run dep check in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 script:
   - make check-links || true
   - make lint
+  - make dep-check
   - make
   - make test-cover
 #  - make test-examples # TODO: refactor tests to not check exact log output

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,11 @@ dep-install: get-dep
 dep-update: get-dep
 	dep ensure -update
 
+# Check state of dependencies
+dep-check: get-dep
+	@echo "=> checking dependencies"
+	dep check
+
 LINTER := $(shell command -v gometalinter 2> /dev/null)
 
 # Get linter tools

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ test-cover-xml: test-cover
 
 # Get dependency manager tool
 get-dep:
-	go get -v github.com/golang/dep/cmd/dep
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+	dep version
 
 # Install the project's dependencies
 dep-install: get-dep


### PR DESCRIPTION
This is from a discussion on #327

Similar to the vpp-agent [1] [2], run `dep check` in travis-ci with each
commit and fail if someone adds vendored code without proper vendoring.

[1] https://github.com/ligato/vpp-agent/blob/pantheon-dev/.travis.yml#L41
[2] https://github.com/ligato/vpp-agent/blob/pantheon-dev/Makefile#L179-L181

Signed-off-by: Kyle Mestery <mestery@mestery.com>