### PR TITLE
Add yamllint to our travis-ci runs

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,3 @@
+---
 require:
   members: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 dist: trusty
 sudo: required
 language: go
@@ -17,6 +18,7 @@ before_install:
   - go get -v github.com/mattn/goveralls
 
 script:
+  - make yamllint
   - make check-links || true
   - make lint
   - make dep-check

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ get-yamllint:
 	pip install --user yamllint
 
 # Lint the yaml files
-yaml-lint: get-yamllint
+yamllint: get-yamllint
 	@echo "=> linting the yaml files"
 	yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
 
@@ -164,4 +164,4 @@ yaml-lint: get-yamllint
 	get-dep dep-install dep-update \
 	get-linters lint format \
 	get-linkcheck check-links \
-	get-yamllint yaml-lint
+	get-yamllint yamllint

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ get-yamllint:
 # Lint the yaml files
 yamllint: get-yamllint
 	@echo "=> linting the yaml files"
-	yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
+	yamllint -c .yamllint.yml $(shell git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
 
 .PHONY: build clean \
 	examples examples-plugin clean-examples clean-examples-plugin test test-examples \

--- a/Makefile
+++ b/Makefile
@@ -149,9 +149,19 @@ check-links: get-linkcheck
 	@echo "=> checking links"
 	./scripts/check_links.sh
 
+# Install yamllint
+get-yamllint:
+	pip install --user yamllint
+
+# Lint the yaml files
+yaml-lint: get-yamllint
+	@echo "=> linting the yaml files"
+	yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
+
 .PHONY: build clean \
 	examples examples-plugin clean-examples clean-examples-plugin test test-examples \
 	test-cover test-cover-html test-cover-xml \
 	get-dep dep-install dep-update \
 	get-linters lint format \
-	get-linkcheck check-links
+	get-linkcheck check-links \
+	get-yamllint yaml-lint

--- a/examples/cassandra-lib/client-config.yaml
+++ b/examples/cassandra-lib/client-config.yaml
@@ -1,8 +1,9 @@
+---
 endpoints:
-- 127.0.0.1:9042
-op_timeout: 5000000000 # 5 seconds (creating a new keyspace is very slow on travis)
-dial_timeout: 3000000000 # 3 seconds
-redial_interval: 60000000000 # 60 seconds
+  - 127.0.0.1:9042
+op_timeout: 5000000000  # 5 seconds (creating a new keyspace is very slow on travis)
+dial_timeout: 3000000000  # 3 seconds
+redial_interval: 60000000000  # 60 seconds
 protocol_version: 4
 tls:
   cert_path: ""

--- a/examples/redis-lib/cluster-client.yaml
+++ b/examples/redis-lib/cluster-client.yaml
@@ -1,10 +1,11 @@
+---
 # github.com/ligato/cn-infra/db/keyval/redis#ClusterConfig
 dial-timeout: 0
 enable-query-on-slave: true
 endpoints:
-- 172.17.0.1:6379
-- 172.17.0.2:6379
-- 172.17.0.3:6379
+  - 172.17.0.1:6379
+  - 172.17.0.2:6379
+  - 172.17.0.3:6379
 max-rediects: 0
 password: ""
 pool:

--- a/examples/redis-lib/node-client.yaml
+++ b/examples/redis-lib/node-client.yaml
@@ -1,3 +1,4 @@
+---
 # github.com/ligato/cn-infra/db/keyval/redis#NodeConfig
 db: 0
 dial-timeout: 0

--- a/examples/redis-lib/sentinel-client.yaml
+++ b/examples/redis-lib/sentinel-client.yaml
@@ -1,10 +1,11 @@
+---
 # github.com/ligato/cn-infra/db/keyval/redis#SentinelConfig
 db: 0
 dial-timeout: 0
 endpoints:
-- 172.17.0.7:26379
-- 172.17.0.8:26379
-- 172.17.0.9:26379
+  - 172.17.0.7:26379
+  - 172.17.0.8:26379
+  - 172.17.0.9:26379
 master-name: mymaster
 password: ""
 pool:


### PR DESCRIPTION
This commit is inspired by a similar commit to Network Service Mesh [1].

Since we are making heavy use of yaml files for Network Service Mesh, we should
ensure these are syntactically correct. We'll use yamllint [2] for this.

This commit adds running of yamllint into our travis-ci runs. It also adds a
custom configuration file which turns the yamllint line length check into a
warning. And finally, it fixes a large amount of yamllint errors in our
existing yaml files.

[1] https://github.com/ligato/networkservicemesh/pull/263
[2] https://github.com/adrienverge/yamllint

Signed-off-by: Kyle Mestery <mestery@mestery.com>