### PR TITLE
plugin lookup resolves slice-type fields

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,7 +1,7 @@
 # Agent [![GoDoc](https://godoc.org/github.com/ligato/cn-infra/agent?status.svg)](https://godoc.org/github.com/ligato/cn-infra/agent)
 
-The **agent** package provides life-cycle managment agent for plugins.
-It intented tp be used as a base point of your program used in main package.
+The **agent** package provides the life-cycle management agent for plugins.
+It is intended to be used as a base point of an application used in main package.
 
 ```go
 func main() {
@@ -18,14 +18,15 @@ func main() {
 
 ## Agent options
 
-There are various options available to customize agent.
+There are various options available to customize agent:
 
 - `Version(ver, date, id)` sets version of the program
-- `QuitOnClose(chan)` sets signal used to quit running agent when closed
-- `QuitSignals(signals)` sets signals used to quit running agent (default: SIGINT, SIGTERM)
+- `QuitOnClose(chan)` sets signal used to quit the running agent when closed
+- `QuitSignals(signals)` sets signals used to quit the running agent (default: SIGINT, SIGTERM)
 - `StartTimeout(dur)/StopTimeout(dur)` sets start/stop timeout (defaults: 15s/5s)
-- add plugins to list of plugins managed by agent using:
-  - `Plugins(...)` adds just single plugins
-  - `AllPlugins(...)` adds plugin along with all of its plugin deps
+
+Add plugins to list of plugins managed by agent using:
+- `Plugins(...)` adds just single plugins
+- `AllPlugins(...)` adds plugin along with all of its plugin deps
   
 See all options [here](https://godoc.org/github.com/ligato/cn-infra/agent#Option).

--- a/db/keyval/redis/plugin_impl_redis.go
+++ b/db/keyval/redis/plugin_impl_redis.go
@@ -70,8 +70,12 @@ func (p *Plugin) Init() (err error) {
 	}
 	p.protoWrapper = kvproto.NewProtoWrapper(p.connection, &keyval.SerializerJSON{})
 
-	// Register for providing status reports (polling mode)
-	if p.StatusCheck != nil {
+	return nil
+}
+
+// AfterInit registers redis to status check if required
+func (p *Plugin) AfterInit() error {
+	if p.StatusCheck != nil && !p.disabled {
 		p.StatusCheck.Register(p.PluginName, func() (statuscheck.PluginState, error) {
 			_, _, err := p.NewBroker("/").GetValue(healthCheckProbeKey, nil)
 			if err == nil {
@@ -79,8 +83,7 @@ func (p *Plugin) Init() (err error) {
 			}
 			return statuscheck.Error, err
 		})
-	} else {
-		p.Log.Warnf("Unable to start status check for redis")
+		p.Log.Infof("Status check for %s was started", p.PluginName)
 	}
 
 	return nil


### PR DESCRIPTION
Plugin lookup does not process slice-type fields (or interfaces where the inner type is slice). Such a field was skipped and all potential plugins inside were ignored, which is causing some cases where the plugin order is still important because the plugin dependency order is not correct.

Example:
VPP plugin defines Publishers with type KeyProtoValWriter, which is an interface representing a list of kvdbsync plugins. Since those plugins were not included, the top level plugin has to define ETCDDataSync (or any other data sync) before the VPP plugin, otherwise, the resolution will fail on unmet dependencies.

This change also causes that the loading order of status check plugin and data sync plugins is reverted (status check defines KeyProtoValWriter, which was skipped before), so the registration was moved to AfterInit().

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>