### PR TITLE
bolt plugin: rewrite watcher

### DIFF
--- a/db/keyval/bolt/bolt.go
+++ b/db/keyval/bolt/bolt.go
@@ -49,7 +49,7 @@ type Client struct {
 	updateChan chan *updateTx
 
 	mu       sync.RWMutex
-	watchers []*prefixWatcher
+	watchers watchers
 
 	wg   sync.WaitGroup
 	quit chan struct{}
@@ -78,6 +78,7 @@ func NewClient(cfg *Config) (client *Client, err error) {
 		cfg:        *cfg,
 		quit:       make(chan struct{}),
 		updateChan: make(chan *updateTx, UpdatesChannelSize),
+		watchers:   make(watchers),
 	}
 
 	c.wg.Add(1)
@@ -197,17 +198,6 @@ func (c *Client) ListValues(keyPrefix string) (keyval.BytesKeyValIterator, error
 	})
 
 	return &bytesKeyValIterator{len: len(pairs), pairs: pairs}, err
-}
-
-// Watch watches given list of key prefixes.
-func (c *Client) Watch(resp func(keyval.BytesWatchResp), closeChan chan string, keys ...string) error {
-	boltLogger.Debugf("Watch: %q", keys)
-	for _, k := range keys {
-		if err := c.watch(resp, closeChan, k); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // NewTxn creates new transaction

--- a/db/keyval/bolt/watch.go
+++ b/db/keyval/bolt/watch.go
@@ -16,22 +16,27 @@ package bolt
 
 import (
 	"bytes"
-	"context"
 	"strings"
 
 	"github.com/ligato/cn-infra/datasync"
 	"github.com/ligato/cn-infra/db/keyval"
 )
 
-func (c *Client) bumpWatchers(we *watchEvent) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+type watchEvent struct {
+	Type      datasync.Op
+	Key       string
+	Value     []byte
+	PrevValue []byte
+	Revision  int64
+}
 
-	for _, w := range c.watchers {
-		if strings.HasPrefix(we.Key, w.prefix) {
-			w.watchCh <- we
-		}
-	}
+type watchers map[chan string]*watcher // close channel -> watcher
+
+type watcher struct {
+	prefixes    []watchPrefix
+	watchCh     chan *watchEvent
+	closeCh     chan string
+	prefixRegCh chan watchPrefix // for registration of new key prefixes to watch
 }
 
 type watchResp struct {
@@ -39,6 +44,25 @@ type watchResp struct {
 	key              string
 	value, prevValue []byte
 	rev              int64
+}
+
+type watchPrefix struct {
+	prefix string
+	cb     watchCallback
+}
+
+type watchCallback func(watchResp keyval.BytesWatchResp)
+
+func (c *Client) bumpWatchers(we *watchEvent) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.cfg.FilterDupNotifs && bytes.Equal(we.Value, we.PrevValue) {
+		return
+	}
+	for _, w := range c.watchers {
+		w.watchCh <- we
+	}
 }
 
 // GetChangeType returns "Put" for BytesWatchPutResp.
@@ -66,85 +90,102 @@ func (resp *watchResp) GetRevision() int64 {
 	return resp.rev
 }
 
-func (c *Client) watch(resp func(watchResp keyval.BytesWatchResp), closeCh chan string, prefix string) error {
-	boltLogger.Debug("watch:", prefix)
+// Watch watches given list of key prefixes.
+func (c *Client) Watch(resp func(watchResp keyval.BytesWatchResp), closeCh chan string, prefixes ...string) error {
+	boltLogger.Debugf("watch: %q", prefixes)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	recvChan := c.watchPrefix(ctx, prefix)
-
-	go func(regPrefix string) {
-		defer cancel()
-		for {
-			select {
-			case ev, ok := <-recvChan:
-				if !ok {
-					boltLogger.WithField("prefix", prefix).
-						Debug("Watch recv chan was closed")
-					return
-				}
-				if c.cfg.FilterDupNotifs && bytes.Equal(ev.Value, ev.PrevValue) {
-					continue
-				}
-				r := &watchResp{
-					typ:       ev.Type,
-					key:       ev.Key,
-					value:     ev.Value,
-					prevValue: ev.PrevValue,
-					rev:       ev.Revision,
-				}
-				resp(r)
-			case closeVal, ok := <-closeCh:
-				if !ok || closeVal == regPrefix {
-					boltLogger.WithField("prefix", prefix).
-						Debug("Watch ended")
-					return
-				}
+	w, exists := c.watchers[closeCh]
+	if exists {
+		// this close channel is already in use
+		for _, prefix := range prefixes {
+			w.prefixRegCh <- watchPrefix{
+				prefix: prefix,
+				cb:     resp,
 			}
 		}
-	}(prefix)
+		return nil
+	}
 
+	// create and register new watcher
+	w = &watcher{
+		prefixes:    make([]watchPrefix, len(prefixes)),
+		watchCh:     make(chan *watchEvent, 10),
+		closeCh:     closeCh,
+		prefixRegCh: make(chan watchPrefix, 10),
+	}
+	for i, prefix := range prefixes {
+		w.prefixes[i] = watchPrefix{
+			prefix: prefix,
+			cb:     resp,
+		}
+	}
+	c.watchers[closeCh] = w
+
+	go func() {
+		w.watch()
+		// un-register when done
+		c.mu.Lock()
+		delete(c.watchers, closeCh)
+		c.mu.Unlock()
+	}()
 	return nil
 }
 
-type watchEvent struct {
-	Type      datasync.Op
-	Key       string
-	Value     []byte
-	PrevValue []byte
-	Revision  int64
-}
-
-type prefixWatcher struct {
-	prefix  string
-	watchCh chan *watchEvent
-}
-
-func (c *Client) watchPrefix(ctx context.Context, prefix string) <-chan *watchEvent {
-	boltLogger.Debug("watchPrefix:", prefix)
-
-	ch := make(chan *watchEvent, 1)
-
-	c.mu.Lock()
-	index := len(c.watchers)
-	c.watchers = append(c.watchers, &prefixWatcher{
-		prefix:  prefix,
-		watchCh: ch,
-	})
-	c.mu.Unlock()
-
-	go func() {
+func (w *watcher) watch() {
+	for {
 		select {
-		case <-ctx.Done():
-			c.mu.Lock()
-			if len(c.watchers) == index+1 {
-				c.watchers = c.watchers[:index]
-			} else {
-				c.watchers = append(c.watchers[:index], c.watchers[index+1:]...)
+		case ev, ok := <-w.watchCh:
+			if !ok {
+				boltLogger.WithField("prefixes", w.prefixes).
+					Debug("Watch channel was closed")
+				return
 			}
-			c.mu.Unlock()
-		}
-	}()
+			var cb watchCallback
+			for _, wp := range w.prefixes {
+				if strings.HasPrefix(ev.Key, wp.prefix) {
+					cb = wp.cb
+					break
+				}
+			}
+			if cb == nil {
+				// key not watched by this watcher
+				continue
+			}
+			r := &watchResp{
+				typ:       ev.Type,
+				key:       ev.Key,
+				value:     ev.Value,
+				prevValue: ev.PrevValue,
+				rev:       ev.Revision,
+			}
+			cb(r)
 
-	return ch
+		case regPrefix, ok := <- w.prefixRegCh:
+			if !ok {
+				boltLogger.WithField("prefixes", w.prefixes).
+					Debug("Prefix-registration channel was closed")
+				return
+			}
+			w.prefixes = append(w.prefixes, regPrefix)
+			boltLogger.WithField("prefixes", w.prefixes).Debug(
+				"The set of watched prefixes was extended")
+
+		case closeVal, ok := <-w.closeCh:
+			if !ok {
+				boltLogger.WithField("prefixes", w.prefixes).Debug("Watch ended")
+				return
+			}
+			for i, wp := range w.prefixes {
+				if wp.prefix == closeVal {
+					boltLogger.WithField("prefix", wp.prefix).Debug("Watch ended")
+					w.prefixes[i] = w.prefixes[len(w.prefixes)-1]
+					w.prefixes = w.prefixes[:len(w.prefixes)-1]
+					break
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
The original implementation had 2 bugs:
- keys sent to the close channel were not prefixed
- key sent to the close channel would be delivered to only one of the
  watching go routines, not necessarily to the one associated with that key
  (causing the request to be ignored in such case)

Furthermore, the original implementation would create quite a lot of
go routines - 2 for every watched prefix. The second go routine from
the pair, which was just waiting for the first to end to perform
the watcher unregistration, could have been easily avoided.

Lastly, a requirement to allow to easily extend the set of watched
prefixes, without having to create another close channel, inspired
the rewrite of the watcher for bolt BD.

With this change, there are now 2 go routines associated with every
close channel. The first, started by prefixed BrokerWatcher, adds
prefix to every key send to the close channel. The second performs
the actual watching for all the prefixes defined for the particular
close channel (close channel is basically "context" here). This
means, for example, that prefixes defined within one Watch() call
will get triggered one after another from the same go routine.

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>