### PR TITLE
etcd plugin: support CAS and env. variable expansion

### DIFF
--- a/db/keyval/bytes_broker_api.go
+++ b/db/keyval/bytes_broker_api.go
@@ -38,6 +38,29 @@ type BytesBroker interface {
 	Delete(key string, opts ...datasync.DelOption) (existed bool, err error)
 }
 
+// BytesBrokerWithAtomic extends BytesBroker with atomic operations.
+// Currently only etcd plugin supports atomic operations.
+type BytesBrokerWithAtomic interface {
+	BytesBroker
+
+	// PutIfNotExists puts given key-value pair into the datastore if there is no value set for the key.
+	// If the put was successful, <succeeded> is returned as true. If the key already exists, <succeeded> is returned
+	// as false and the value for the key is untouched.
+	PutIfNotExists(key string, data []byte) (succeeded bool, err error)
+
+	// CompareAndSwap compares the value currently stored under the given key with the expected <oldData>,
+	// and only if the expected and actual data match, the value is then changed to <newData>. The comparison and the
+	// value change are executed together in a single transaction and cannot be interleaved with another operation for
+	// that key.
+	CompareAndSwap(key string, oldData, newData []byte) (swapped bool, err error)
+
+	// CompareAndDelete compares the value currently stored under the given key with the expected <data>,
+	// and only if the expected and actual data match, the value is then removed from the datastore. The comparison and
+	// the value removal are executed together in a single transaction and cannot be interleaved with another operation
+	// for that key.
+	CompareAndDelete(key string, data []byte) (deleted bool, err error)
+}
+
 // BytesTxn allows to group operations into the transaction.
 // Transaction executes multiple operations in a more efficient way in contrast
 // to executing them one by one.

--- a/db/keyval/etcd/config.go
+++ b/db/keyval/etcd/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	AllowDelayedStart     bool          `json:"allow-delayed-start"`
 	ReconnectInterval     time.Duration `json:"reconnect-interval"`
 	SessionTTL            int           `json:"session-ttl"`
+	ExpandEnvVars         bool          `json:"expand-env-variables"`
 }
 
 // ClientConfig extends clientv3.Config with configuration options introduced
@@ -57,6 +58,11 @@ type ClientConfig struct {
 	// SessionTTL is default TTL (in seconds) used by client in RunElection or WithClientLifetimeTTL put option.
 	// Once given number of seconds elapses without value's lease renewal the value is removed.
 	SessionTTL int
+
+	// ExpandEnvVars, if enabled, will cause the JSON value serializer to replace ${var} or $var in received JSON
+	// data according to the values of the current environment variables. References to undefined variables are replaced
+	// by the empty string.
+	ExpandEnvVars bool
 }
 
 const (
@@ -110,6 +116,8 @@ func ConfigToClient(yc *Config) (*ClientConfig, error) {
 			cfg.Endpoints = []string{"127.0.0.1:2379"}
 		}
 	}
+
+	cfg.ExpandEnvVars = yc.ExpandEnvVars || os.Getenv("ETCD_EXPAND_ENV_VARS") != ""
 
 	if yc.InsecureTransport {
 		cfg.TLS = nil

--- a/db/keyval/etcd/plugin_impl_etcd.go
+++ b/db/keyval/etcd/plugin_impl_etcd.go
@@ -107,7 +107,7 @@ func (p *Plugin) Init() (err error) {
 	}
 
 	// If successful, configure and return
-	p.configureConnection()
+	p.configureConnection(etcdClientCfg.ExpandEnvVars)
 
 	// Mark p as connected at this point
 	p.connected = true
@@ -140,6 +140,13 @@ func (p *Plugin) NewWatcher(keyPrefix string) keyval.ProtoWatcher {
 	return p.protoWrapper.NewWatcher(keyPrefix)
 }
 
+// NewBrokerWithAtomic creates new instance of prefixed (byte-oriented) broker with atomic operations.
+// It is equivalent to: RawAccess().NewBroker(keyPrefix).(keyval.BytesBrokerWithAtomic), but the presence of this
+// method can be used as a compile-time check for the support of atomic operations (of an injected dependency).
+func (p *Plugin) NewBrokerWithAtomic(keyPrefix string) keyval.BytesBrokerWithAtomic {
+	return p.connection.NewBroker(keyPrefix).(keyval.BytesBrokerWithAtomic)
+}
+
 // RawAccess allows to access data in the database as raw bytes (i.e. not formatted by protobuf).
 func (p *Plugin) RawAccess() keyval.KvBytesPlugin {
 	return p.connection
@@ -168,15 +175,6 @@ func (p *Plugin) OnConnect(callback func() error) {
 // GetPluginName returns name of the plugin
 func (p *Plugin) GetPluginName() infra.PluginName {
 	return p.PluginName
-}
-
-// PutIfNotExists puts given key-value pair into etcd if there is no value set for the key. If the put was successful
-// succeeded is true. If the key already exists succeeded is false and the value for the key is untouched.
-func (p *Plugin) PutIfNotExists(key string, value []byte) (succeeded bool, err error) {
-	if p.connection != nil {
-		return p.connection.PutIfNotExists(key, value)
-	}
-	return false, fmt.Errorf("connection is not established")
 }
 
 // CampaignInElection starts campaign in leader election on a given prefix. Multiple instances can compete on a given prefix.
@@ -216,19 +214,19 @@ func (p *Plugin) etcdReconnectionLoop(clientCfg *ClientConfig) {
 		if err != nil {
 			continue
 		}
-		p.setupPostInitConnection()
+		p.setupPostInitConnection(clientCfg.ExpandEnvVars)
 		return
 	}
 }
 
-func (p *Plugin) setupPostInitConnection() {
+func (p *Plugin) setupPostInitConnection(expandEnvVars bool) {
 	p.Log.Infof("ETCD server %s connected", p.config.Endpoints)
 
 	p.Lock()
 	defer p.Unlock()
 
 	// Configure connection and set as connected
-	p.configureConnection()
+	p.configureConnection(expandEnvVars)
 	p.connected = true
 
 	// Execute callback functions (if any)
@@ -246,7 +244,7 @@ func (p *Plugin) setupPostInitConnection() {
 }
 
 // If ETCD is connected, complete all other procedures
-func (p *Plugin) configureConnection() {
+func (p *Plugin) configureConnection(expandEnvVars bool) {
 	if p.config.AutoCompact > 0 {
 		if p.config.AutoCompact < time.Duration(time.Minute*60) {
 			p.Log.Warnf("Auto compact option for ETCD is set to less than 60 minutes!")
@@ -257,7 +255,7 @@ func (p *Plugin) configureConnection() {
 	if p.Serializer != nil {
 		serializer = p.Serializer
 	} else {
-		serializer = &keyval.SerializerJSON{}
+		serializer = &keyval.SerializerJSON{ExpandEnvVars: expandEnvVars}
 	}
 	p.protoWrapper = kvproto.NewProtoWrapper(p.connection, serializer)
 }

--- a/db/keyval/proto_serializer.go
+++ b/db/keyval/proto_serializer.go
@@ -16,6 +16,7 @@ package keyval
 
 import (
 	"bytes"
+	"os"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -50,11 +51,17 @@ func (sp *SerializerProto) Marshal(message proto.Message) ([]byte, error) {
 }
 
 // SerializerJSON serializes proto message using JSON serializer.
-type SerializerJSON struct{}
+type SerializerJSON struct{
+	ExpandEnvVars bool
+}
 
 // Unmarshal deserializes data from slice of bytes into the provided protobuf
 // message using jsonpb marshaller to correctly unmarshal protobuf data.
 func (sj *SerializerJSON) Unmarshal(data []byte, protoData proto.Message) error {
+	if sj.ExpandEnvVars {
+		expandedData := os.ExpandEnv(string(data))
+		return jsonpb.Unmarshal(bytes.NewBufferString(expandedData), protoData)
+	}
 	return jsonpb.Unmarshal(bytes.NewBuffer(data), protoData)
 }
 


### PR DESCRIPTION
This PR enhances etcd plugin with the following features:
- CompareAndSwap (CAS) operation - i.e. atomically compare and swap
- environment variable expansion - value put into etcd may reference environment variables which will be expanded before the value is dispatched into the orchestrator plugin and further down the processing stack

Signed-off-by: Milan Lenco <milenco@cisco.com>