### PR TITLE
feat: gRPC plugin support TLS from config file

### DIFF
--- a/rpc/grpc/grpc.conf
+++ b/rpc/grpc/grpc.conf
@@ -17,3 +17,21 @@ max-msg-size: 4096
 
 # Limit of server streams to each server transport.
 max-concurrent-streams: 0
+
+# TLS configuration:
+
+# If `true` TLS configuration from this config will be SKIPPED.
+#insecure-transport: false
+
+# If `true` server skips verification of client's certificate
+#insecure-skip-tls-verify: true
+
+# Required for creating secure connection.
+#cert-file: /path/to/cert.pem
+
+# Also required for creating secure connection.
+#key-file: /path/to/key.pem
+
+# Set custom CA to verify client's certificate against it.
+# Affects only if `insecure-skip-tls-verify` set to `false` (or not set).
+#ca-file: /path/to/ca.pem

--- a/rpc/grpc/plugin_impl_grpc.go
+++ b/rpc/grpc/plugin_impl_grpc.go
@@ -75,6 +75,7 @@ func (p *Plugin) Init() (err error) {
 		}
 
 		if p.tlsConfig != nil {
+			p.Log.Info("Secure connection for gRPC enabled")
 			opts = append(opts, grpc.Creds(credentials.NewTLS(p.tlsConfig)))
 		}
 

--- a/rpc/grpc/plugin_impl_grpc.go
+++ b/rpc/grpc/plugin_impl_grpc.go
@@ -64,9 +64,20 @@ func (p *Plugin) Init() (err error) {
 	// Prepare GRPC server
 	if p.grpcServer == nil {
 		opts := p.Config.getGrpcOptions()
+
+		// If config for TLS was not provided with the `UseTLS` option, check config file.
+		if p.tlsConfig == nil {
+			tc, err := p.Config.getTLS()
+			if err != nil {
+				return err
+			}
+			p.tlsConfig = tc
+		}
+
 		if p.tlsConfig != nil {
 			opts = append(opts, grpc.Creds(credentials.NewTLS(p.tlsConfig)))
 		}
+
 		if p.auther != nil {
 			p.Log.Info("Token authentication for gRPC enabled")
 			opts = append(opts, grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(p.auther.Authenticate)))


### PR DESCRIPTION
now configuration for gRPC can look like this:
```
endpoint: 0.0.0.0:9111
cert-file: /path/to/server.crt
key-file: /path/to/server.key
ca-file: /path/to/ca.crt
```
