### PR TITLE
feat: enable grpc plugin logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ examples/etcd-lib/election/election
 examples/etcd-lib/view/view
 examples/etcd-lib/watcher/watcher
 examples/flags-lib/flags-lib
+examples/grpc-plugin/grpc-client/grpc-client
 examples/grpc-plugin/grpc-server/grpc-server
 examples/kafka-lib/asyncproducer/asyncproducer
 examples/kafka-lib/consumer/consumer

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -997,6 +997,7 @@
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/examples/helloworld/helloworld",
+    "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/metadata",
     "google.golang.org/grpc/peer",
     "google.golang.org/grpc/status",

--- a/examples/grpc-plugin/README.md
+++ b/examples/grpc-plugin/README.md
@@ -1,12 +1,18 @@
 # grpc-plugin
 
-To run the `grpc-server` example, simply type in grpc-server folder:
+Start the `grpc-server` example typing following in the grpc-server folder:
 ```
-go run main.go deps.go [--grpc-config=<config-filepath>]
+go run main.go 
 ```
 
-To run the `grpc-client` example, simply type in grpc-client folder:
+In order to pass custom configuration file (for example the `grpc.conf` located in the same directory), start grpc-server with following parameter:
 ```
-go run main.go deps.go
+go run main --grpc-config=<config-filepath>
+```
+Note: `main.go` must be edited in this case because it makes use of the direct config injection via `grpc.UseConf` method, which overrides any provided config file. To enable it, remove method mentioned. 
+
+Start the `grpc-client` exampl typing following in the grpc-client folder:
+```
+go run main.go
 ```
 

--- a/examples/grpc-plugin/grpc-server/grpc.conf
+++ b/examples/grpc-plugin/grpc-server/grpc.conf
@@ -1,1 +1,2 @@
-Endpoint: "0.0.0.0:9111"
+endpoint: "0.0.0.0:9111"
+extended-logging: true

--- a/examples/grpc-plugin/grpc-server/main.go
+++ b/examples/grpc-plugin/grpc-server/main.go
@@ -25,9 +25,6 @@ const PluginName = "myPlugin"
 func main() {
 	grpcPlug := grpc.NewPlugin(
 		grpc.UseHTTP(&rest.DefaultPlugin),
-		grpc.UseConf(grpc.Config{
-			Endpoint: "localhost:9111",
-		}),
 		grpc.UseAuth(&grpc.Authenticator{
 			Username: "testuser",
 			Password: "testpwd",

--- a/examples/grpc-plugin/grpc-server/main.go
+++ b/examples/grpc-plugin/grpc-server/main.go
@@ -25,6 +25,11 @@ const PluginName = "myPlugin"
 func main() {
 	grpcPlug := grpc.NewPlugin(
 		grpc.UseHTTP(&rest.DefaultPlugin),
+		// Remove 'UseConf' in order to allow GRPC config file
+		grpc.UseConf(grpc.Config{
+			Endpoint: "localhost:9111",
+			ExtendedLogging: true,
+		}),
 		grpc.UseAuth(&grpc.Authenticator{
 			Username: "testuser",
 			Password: "testpwd",

--- a/rpc/grpc/config.go
+++ b/rpc/grpc/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	Keyfile           string   `json:"key-file"`
 	CAfiles           []string `json:"ca-files"`
 
+	// ExtendedLogging enables detailed GRPC logging
+	ExtendedLogging bool `json:"extended-logging"`
+
 	// Compression for inbound/outbound messages.
 	// Supported only gzip.
 	//TODO Compression string

--- a/rpc/grpc/grpc.conf
+++ b/rpc/grpc/grpc.conf
@@ -31,6 +31,9 @@ max-concurrent-streams: 0
 
 # Set custom CA to verify client's certificate.
 # If not set, client's certificate is not required.
-#ca-files: 
+#ca-files:
 #  - /path/to/ca1.pem
 #  - /path/to/ca2.pem
+
+# Enables logging additional GRPC transport messages
+extended-logging: false


### PR DESCRIPTION
* Enable GRPC logging
* Additional GRPC transport messages can be enabled with `extended-logging` set to `true` in the config file (these are disabled by default since there is plenty of them)

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>