### PR TITLE
fix: Assign CA certs to correct cert pool in GRPC plugin

### DIFF
--- a/rpc/grpc/grpc.conf
+++ b/rpc/grpc/grpc.conf
@@ -23,15 +23,14 @@ max-concurrent-streams: 0
 # If `true` TLS configuration from this config will be SKIPPED.
 #insecure-transport: false
 
-# If `true` server skips verification of client's certificate
-#insecure-skip-tls-verify: true
-
 # Required for creating secure connection.
 #cert-file: /path/to/cert.pem
 
 # Also required for creating secure connection.
 #key-file: /path/to/key.pem
 
-# Set custom CA to verify client's certificate against it.
-# Affects only if `insecure-skip-tls-verify` set to `false` (or not set).
-#ca-file: /path/to/ca.pem
+# Set custom CA to verify client's certificate.
+# If not set, client's certificate is not required.
+#ca-files: 
+#  - /path/to/ca1.pem
+#  - /path/to/ca2.pem


### PR DESCRIPTION
Yesterday, I've made a mistake with assigning CA certs to `RootCAs` and not to `ClientCAs`. Srry

This bug was introduced here #412 