### PR TITLE
feat: Add options to grpc plugin for adding ServerOption and enabling metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/gorilla/mux v1.6.2
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.5.1 // indirect
 	github.com/hashicorp/consul v1.3.0
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect

--- a/rpc/grpc/config.go
+++ b/rpc/grpc/config.go
@@ -62,17 +62,20 @@ type Config struct {
 	// ExtendedLogging enables detailed GRPC logging
 	ExtendedLogging bool `json:"extended-logging"`
 
+	// PrometheusMetrics enables prometheus metrics for gRPC client.
+	PrometheusMetrics bool `json:"prometheus-metrics"`
+
 	// Compression for inbound/outbound messages.
 	// Supported only gzip.
 	//TODO Compression string
 }
 
 func (cfg *Config) getGrpcOptions() (opts []grpc.ServerOption) {
-	switch {
-	case cfg.MaxConcurrentStreams > 0:
+	if cfg.MaxConcurrentStreams > 0 {
 		opts = append(opts, grpc.MaxConcurrentStreams(cfg.MaxConcurrentStreams))
-	case cfg.MaxMsgSize > 0:
-		opts = append(opts, grpc.MaxMsgSize(cfg.MaxMsgSize))
+	}
+	if cfg.MaxMsgSize > 0 {
+		opts = append(opts, grpc.MaxRecvMsgSize(cfg.MaxMsgSize))
 	}
 	return
 }

--- a/rpc/grpc/grpc.conf
+++ b/rpc/grpc/grpc.conf
@@ -36,4 +36,7 @@ max-concurrent-streams: 0
 #  - /path/to/ca2.pem
 
 # Enables logging additional GRPC transport messages
-extended-logging: false
+#extended-logging: false
+
+# Enables prometheus metrics for GRPC server
+#prometheus-metrics: false

--- a/rpc/grpc/options.go
+++ b/rpc/grpc/options.go
@@ -18,6 +18,9 @@ import (
 	"crypto/tls"
 	"fmt"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"google.golang.org/grpc"
+
 	"go.ligato.io/cn-infra/v2/config"
 	"go.ligato.io/cn-infra/v2/logging"
 	"go.ligato.io/cn-infra/v2/rpc/rest"
@@ -75,16 +78,30 @@ func UseHTTP(h rest.HTTPHandlers) Option {
 	}
 }
 
-// UseAuth return Option that sets Authenticator.
+// UseAuth returns Option that sets Authenticator.
 func UseAuth(a *Authenticator) Option {
 	return func(p *Plugin) {
 		p.auther = a
 	}
 }
 
-// UseTLS return Option that sets TLS config.
+// UseTLS returns Option that sets TLS config.
 func UseTLS(c *tls.Config) Option {
 	return func(p *Plugin) {
 		p.tlsConfig = c
+	}
+}
+
+// UseServerOpts returns Option that adds server options.
+func UseServerOpts(o ...grpc.ServerOption) Option {
+	return func(p *Plugin) {
+		p.serverOpts = append(p.serverOpts, o...)
+	}
+}
+
+// UsePromMetrics returns Option that sets custom server metrics.
+func UsePromMetrics(metrics *grpc_prometheus.ServerMetrics) Option {
+	return func(p *Plugin) {
+		p.metrics = metrics
 	}
 }


### PR DESCRIPTION
This PR adds two new options to grpc plugin:
- `UseServerOpts` to add extra `grpc.ServerOption`s
- `UsePromMetrics` to set custom `grpc_prometheus.ServerMetrics`

The config file has new option `PrometheusMetrics` for enabling default prometheus metrics  for grpc server. Setting this config option is enough to enable metrics.

