### PR TITLE
Update config.go

### DIFF
--- a/rpc/rest/config.go
+++ b/rpc/rest/config.go
@@ -182,7 +182,7 @@ func (cfg *Config) UseHTTPS() bool {
 func DeclareHTTPPortFlag(pluginName infra.PluginName, defaultPortOpts ...uint) {
 	var defaultPort string
 	if len(defaultPortOpts) > 0 {
-		defaultPort = string(defaultPortOpts[0])
+		defaultPort = fmt.Sprint(defaultPortOpts[0])
 	} else {
 		defaultPort = DefaultHTTPPort
 	}

--- a/rpc/rest/config.go
+++ b/rpc/rest/config.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"


### PR DESCRIPTION
Fix conversion to string. This should fix travis failures occuring since Go 1.15 was released. Go vet becoming more strict.